### PR TITLE
1.0.5hotfix -> main

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -222,7 +222,7 @@ hash = "7d2603622a69d297ff628bc6e2e80d77aa146a75de45e1acec6ccc477b905885"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/3__electrical_age.snbt"
-hash = "e893ba3a421d774ee8c6c3006501257d473c52e7ce22fbd5d037390ff86cb723"
+hash = "aedcf0b60c086af85235062eefba0efd97badf85789abbd9a60fcd87e6504e81"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/4__digital_age.snbt"
@@ -230,7 +230,7 @@ hash = "b8611955c8b48e7b338afc439048637b2b4945064bf6c2fb0666867be4dcacc9"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/5__nuclear_age.snbt"
-hash = "0f481516d4a9d5918fcba7ac4f1741c7b4fd4be3e1dfe59d705d9230a56df48b"
+hash = "70125b683512b563a5a3e0239136015ae275ef86827e473cfe6ef6141a83b7cb"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/6__quantum_age.snbt"
@@ -258,7 +258,7 @@ hash = "576a02748dc85662c5b41e64f40a58dcb4d571973c1b80a017dd299e6aa87d34"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/welcome.snbt"
-hash = "1aa0a6c55b29c97cc13781d885b5f8fbfa9b5da2ffe12ebba060728ab90ff126"
+hash = "ca637589af38edd9fb6b968c5d19d55a3df469c31dad834a18a7312b0ee288c9"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/world_of_magic.snbt"
@@ -506,7 +506,7 @@ hash = "02d6feb3afe1d9c96e137f8baaa71de982f1af0a2b37fbcba73f34ee59ebbd4d"
 
 [[files]]
 file = "kubejs/assets/kubejs/lang/en_us.json"
-hash = "93551fed89ffa5bc0ec6ccbc3b60b68d0d0f0fc94681e04fa7fe1e80507a0487"
+hash = "5cdcbc5079d6a94c5a1fe39a9db374826b9b39e97b34504a889eba5a22dccb80"
 
 [[files]]
 file = "kubejs/assets/kubejs/ponder/advanced_large_steam_boiler.nbt"
@@ -722,7 +722,7 @@ hash = "b9146a3824c5d9fbe75c421ddccc4538253ab0ace287fd208bcc7e210fa70b3a"
 
 [[files]]
 file = "kubejs/assets/modern_industrialization/lang/en_us.json"
-hash = "a926b0a28b74aa56b16a23254bdfe335eb3c873b46226c0318cb85033be9d39d"
+hash = "cd42a24af2235713119e3c9cc8a9a2853b006083d60676c194e7fa81b226624e"
 
 [[files]]
 file = "kubejs/assets/modern_industrialization/models/machine/alloy_smelter.json"
@@ -806,7 +806,7 @@ hash = "ddf38bd134c1eacba63812f203a0604f315fcd5bd06f027ac9244de284d6d431"
 
 [[files]]
 file = "kubejs/assets/ponderjs_generated/lang/en_us.json"
-hash = "886529360a4937f990e8161bb1658a4c651193fc48a4d055824d773c2c301f4d"
+hash = "92b6620cc9ebfa2ce45b4a716558f1975e3164296141bbd488d7fec5b5e0dba6"
 
 [[files]]
 file = "kubejs/assets/statech/textures/item/bronze_pump.png"
@@ -938,7 +938,7 @@ hash = "583ad98081fc3c37bb16f4268cce3d5c6d2a63e27f7daaf1741bcca85f4dbf0d"
 
 [[files]]
 file = "kubejs/client_scripts/ponder/modern_industrialization/tag.js"
-hash = "1826b2545289206e70fd595f921068b3707b81191e2a5e66cafa7407ff3c1aa2"
+hash = "20a2c622cbdba59b61e2d07aeb038ae6248d65e47f927c6190348bed3378755e"
 
 [[files]]
 file = "kubejs/client_scripts/ponder/modern_industrialization/vacuum_freezer.js"
@@ -982,11 +982,11 @@ hash = "9e5d6503084eab0b28c070b72c0b715eee826a36a0e26bf47deec7b52687f2ac"
 
 [[files]]
 file = "kubejs/client_scripts/rename.js"
-hash = "0d227b401810a316c19a4c12b70b82a84266f555f0f6ec1d541b4547c148d52f"
+hash = "a571156be5a0d3d754a7fdbe4d1b6334b71f3b90582d36e60919340156733c0d"
 
 [[files]]
 file = "kubejs/client_scripts/tooltip.js"
-hash = "486bcd9af96de6778315075f7772c1187e05a86d0a3c2c55da8bf4213096680e"
+hash = "6c76a669b9e9f47b64f5e482e32088d2fdeb93dfab230d4f7f2992bb2514b602"
 
 [[files]]
 file = "kubejs/config/client.properties"
@@ -1518,7 +1518,7 @@ hash = "f83150db980df37f28dc9eab047862e85e679fbaa9a3a5d7b999c65b03e6e892"
 
 [[files]]
 file = "kubejs/server_scripts/mi_replicatorblacklist.js"
-hash = "3e3d7e0c4adf9ff436888f6f3dd51eb09d7faccb11720da292326ac4736f614a"
+hash = "f2dea704e24f0d0695202bfa6e65ba4435ac386bb5d5fa6c4f5ed7a7ac41eca0"
 
 [[files]]
 file = "kubejs/server_scripts/mods/ad_astra.js"
@@ -1558,7 +1558,7 @@ hash = "f9f73a855bf16eb111618c325012018c3f5922c0b4a5c73534190487c3b8c1a4"
 
 [[files]]
 file = "kubejs/server_scripts/mods/create.js"
-hash = "7d01b7cfd5571b508c4cc221bbacbabcaa90ff9b058e058819940892c4e8e9ea"
+hash = "4d7697a8ef12fa2292e7f14d9fa3ee2d4032fb91405bd7152242befc6208639c"
 
 [[files]]
 file = "kubejs/server_scripts/mods/createaddition.js"
@@ -1610,7 +1610,7 @@ hash = "bd7ed2d50fe910c36e3e21521ac6aec95a2cccbbba7618a35a8ed78e8c682c74"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization.js"
-hash = "c49ed7b477363684c76277446dc9e466032b4edd13b2f2cae7d46376f0a09be7"
+hash = "9ac8a1d5630024b98cf657118182e0d47b823878feedc8d1d1404dc9f9c3b07b"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/alloy_smelter.js"
@@ -1618,11 +1618,11 @@ hash = "90b478a5de706f7543264da4206f8db9ed48353032e3a986fdab7aa22a2013a1"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/assembler.js"
-hash = "15a77d0419e6b0ea0c127df5325c49da1cb3955a7baa1d7ec4c5abd2f8ac7473"
+hash = "0c55747c9cd93f4cff30137142e917242f7f2e39bcfa3527e267f22f1efa853a"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/blast_furnace.js"
-hash = "ca4a2cd9193253f3eb971ae42ec2a5d11418dd6a8bfe3a46c19d6f8567f17ee2"
+hash = "dceeb528eb59d42e93eeaf14aac1aaf13210a706964875200e7d876186af1581"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/centrifuge.js"
@@ -1630,7 +1630,7 @@ hash = "1d9e255cba2db0d258c7e0af0f52b202db5433026a173a239edcea5cd1865fd2"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/chemical_reactor.js"
-hash = "0eba549327f328266dc0e2bda8be2019ecd2c4293068c64619df12417f688387"
+hash = "6907768a1291a17d255c5b38edded4c7630b27cab4cd4c57431a57f1fe90f134"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/compressor.js"
@@ -1642,7 +1642,7 @@ hash = "7abb3ef5f691bb2743760120e12756e94acceb3c57949ddfbf2a59834cd808a2"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/electrolyzer.js"
-hash = "d889f20a27df64104ae4095caa1e90ec957706ff06f3c903b648ed2f69f22272"
+hash = "63de2fff60e08a2e62c09efbeeb2c5e9ae8d9b1fbddfc4946cc08829a0eabf7a"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/forge_hammer.js"
@@ -1662,23 +1662,23 @@ hash = "7a6c0aa9c337f37d2a400fd9935873b1ad6d7290d788cd3b05b4126ea11dabcb"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/mega_smelter.js"
-hash = "a0838374b701bc542229520c9ed77b0c87770570a49b3ac06ea64560e80e93bd"
+hash = "56b3d07fece4ad5fd6aeba58d6fe85591ac3ba8defb4333b608090e9c8657d5e"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/mixer.js"
-hash = "9f13a2a7b6d1e3a53296afd6d9c5b471d1792725693ab9a8262ab30412591c4c"
+hash = "4403edb477b4e26e99917ab3791c5ec1621f51930ed11410d5e857ce440571f4"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/packer.js"
-hash = "3feddbfccad29e14668df7a5680032f5f3847b1c0c4a4064f3f9f7f71e6b5659"
+hash = "f80ab8afe8e4192814f717daaf38199fa2c540688c145b4622da94c9d639073d"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/pyrolyse_oven.js"
-hash = "2f06ae52f77c95bc2501a3ca8bc6ed8de992bf3ffb49b8886124724369275880"
+hash = "94e42d0234013a212e6f6fd13d1b56206db9588d6a3c044dd25739e2cc408553"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/quarry.js"
-hash = "4dd36cbbdf21778b26ad6ec5323622d544d8343be60ba0069dbf057944289216"
+hash = "c95cf6aa8555b601ed0eeab403c65e57fe494c95bbf9756ce06b419fb6613152"
 
 [[files]]
 file = "kubejs/server_scripts/mods/modern_industrialization/rocket_part_assembler.js"
@@ -1706,7 +1706,7 @@ hash = "08f311d18801cb4bd6a0c58ed3d2eeb4e90e6896345360cd958748180810edd6"
 
 [[files]]
 file = "kubejs/server_scripts/mods/spectrum.js"
-hash = "5f0f3d2da6119f46966fda38eac018136e23199bba877e07d2d44f6466e25d0b"
+hash = "35ea57a74416ed7b335b81b9bfeda8b03e56b095ae7c79a1615fd8b77f5caf1a"
 
 [[files]]
 file = "kubejs/server_scripts/mods/spellblade.js"
@@ -1722,7 +1722,7 @@ hash = "dcffb449bc85a6f2044204b79913b9fd7bf1a2d15277d30de010d04d0c6d161e"
 
 [[files]]
 file = "kubejs/server_scripts/mods/techreborn.js"
-hash = "27c06c79338f8730997e373127afd4ff04906cf2175ee4c65c906e339445ccfa"
+hash = "298a05f5f313964a31b25c57f697efbd5af6f8e5d9dff401ab2ec08865e7aaf2"
 
 [[files]]
 file = "kubejs/server_scripts/mods/timeinabottle.js"
@@ -1766,7 +1766,7 @@ hash = "33b610a1881dcd5577c073140a44368d6799dc58a4a1de0394fab0d00446cf92"
 
 [[files]]
 file = "kubejs/startup_scripts/modern_industrialization.js"
-hash = "438380730e4cde4a53a0a80537d1ab6918a61ddbbae447d70691bd2a5e11d188"
+hash = "0664fe3410ed6970b1dd11206fe57a510c8273b0d6b17687f54e6d5aa69b59ea"
 
 [[files]]
 file = "kubejs/startup_scripts/ores.js"
@@ -1774,7 +1774,7 @@ hash = "ba8182fe0a6dd628fb4077f212eb80e680122e191f5ba4858a1b1390f5e212f1"
 
 [[files]]
 file = "kubejs/startup_scripts/statech.js"
-hash = "74f15789b4fefa87a8258ec97d2fd6608d86ed8fa39dbe4a1f5caed2d9ade8b7"
+hash = "6c08aee380d07de97457e02cb54c9f3022e25e279d61212acd5157841dd40e88"
 
 [[files]]
 file = "mods/ad-astra-giselle-addon.pw.toml"
@@ -1788,7 +1788,7 @@ metafile = true
 
 [[files]]
 file = "mods/adaptive-tooltips.pw.toml"
-hash = "e178101c4041dd5dc6172a9d67d9eebf97e4cd8283f59f999518ae097bda94f6"
+hash = "7d33dbe3cc230d2ceb5062d495c376d6489d14e9875df14269118ec15cdae18a"
 metafile = true
 
 [[files]]
@@ -1803,12 +1803,12 @@ metafile = true
 
 [[files]]
 file = "mods/alternate-current.pw.toml"
-hash = "6275e0275d58fa55ee243a181b740575e47a7191279ecfa6303130af41a994cc"
+hash = "74d767d0561b0d42e42df3a867d65ebf61517dcdd45e3a8697bd7fc783933d5b"
 metafile = true
 
 [[files]]
 file = "mods/amplified-nether.pw.toml"
-hash = "1a9a37c7485a78018f3d8ae5036f81426e21208d6fbb7fece863c52aab49084a"
+hash = "971d6fe3f20f99c8fbee0c2671426cd7f203bade3a0f530a3f15d200e83b7fdb"
 metafile = true
 
 [[files]]
@@ -1858,7 +1858,7 @@ metafile = true
 
 [[files]]
 file = "mods/auth-me.pw.toml"
-hash = "1be55e4aaad3226c69a8b26804b7986673cf688467a3013c953a0371849da27b"
+hash = "2ae4b2eef35551faa4646e1c567ca5bb28b2255de5143f418227f489863f3b76"
 metafile = true
 
 [[files]]
@@ -1913,22 +1913,22 @@ metafile = true
 
 [[files]]
 file = "mods/better-fps-render-distance-fabric.pw.toml"
-hash = "c2ddb78c7afd8ba15393f04d36bfa8ae4a9ec15a108d86bf7cc7cbfde9a93266"
+hash = "03815e26fa04787fc6b3d94090c3df35b196544ea8254f44bdf013c4049a9d1a"
 metafile = true
 
 [[files]]
 file = "mods/better-mount-hud.pw.toml"
-hash = "92ece2347f99334d812c192ce80b71394ed46e816980afe2e5472564f3e125af"
+hash = "c89740bee8ff9e54519cddccab885be9c38b914ce58e2985a7fa29b45a1572ad"
 metafile = true
 
 [[files]]
 file = "mods/better-ping-display-fabric.pw.toml"
-hash = "610422d9003ede88093e70c77bfc1636fda38adaa6fa139861a8e420b68f7ffe"
+hash = "63b662787d3c163a2676514ceee89baeb7d1658a62a419a7088f0229252adbba"
 metafile = true
 
 [[files]]
 file = "mods/better-stats.pw.toml"
-hash = "10c49474e3fa597dce2e2cdf52e0a8bc4a7b6b24bb0f4c746107c0625397aeb2"
+hash = "a6d03a7fccea1a95c1acff10e52b42ed2eaeb9908dc18c5ff9f2083e3d10694a"
 metafile = true
 
 [[files]]
@@ -1943,7 +1943,7 @@ metafile = true
 
 [[files]]
 file = "mods/blur-fabric.pw.toml"
-hash = "eeba8096624af6233fb83b53905322d1880a3370db7c57db84b8ee5bc0dc63b3"
+hash = "3125e23b0b3c90e1d2c317ab78778f60cc73371d8f15e520bb252712cf02ab7a"
 metafile = true
 
 [[files]]
@@ -2003,12 +2003,12 @@ metafile = true
 
 [[files]]
 file = "mods/charm-of-undying-fabric.pw.toml"
-hash = "8d3655abebd25185ee1b8e37cf4cdc6636dcb5175aa50acd935790359f8a400e"
+hash = "caa0bfd31335bd0c6d50b23df7e8e2634c7edaacbd523c168713ece6f3c8268c"
 metafile = true
 
 [[files]]
 file = "mods/chat-heads.pw.toml"
-hash = "33fa7dcacec319296fd68ca20526ae6d74a5a5c38c8b9167e1bfd5377255ee18"
+hash = "1be98c06e24492771d4c9743d92b5b7cb3a5f3cf2b32d2551c806f00343bb5bf"
 metafile = true
 
 [[files]]
@@ -2033,7 +2033,7 @@ metafile = true
 
 [[files]]
 file = "mods/choicetheorems-overhauled-village.pw.toml"
-hash = "bfd40750a4ce6a6a7f97a0fed7ead088bb4d10dff4a27cb15ee6af4267da3e20"
+hash = "96baebe59a9b637aa80cc15181afeb698f39910d225ca28c8e070a532eb40c0a"
 metafile = true
 
 [[files]]
@@ -2073,7 +2073,7 @@ metafile = true
 
 [[files]]
 file = "mods/collective.pw.toml"
-hash = "1584c24561d1b84c8a0be57cdb1c36d4330014ffa43873d030d0ea191ec89c54"
+hash = "f8266b5cb670f8d5a800f934a173a7d0eba0d34284c59b49d9f4982b7003c491"
 metafile = true
 
 [[files]]
@@ -2083,7 +2083,7 @@ metafile = true
 
 [[files]]
 file = "mods/continuity.pw.toml"
-hash = "fc58e32310426de3ff7c283626668217f69c2c5fcbda5741f37a223556e3ce27"
+hash = "7a653029a3647512cfb3a92e9f4c2393648b5e34af7937e7fba20a19b9441230"
 metafile = true
 
 [[files]]
@@ -2128,7 +2128,7 @@ metafile = true
 
 [[files]]
 file = "mods/cull-less-leaves.pw.toml"
-hash = "8a2b42796d3995659bb5afba5a523e976a1f7beb9dbd0c04790ac2a57f86e043"
+hash = "0dfdd96b301f069a59f378a987d07e97cfb0961bfba88b0e5601734360c9069b"
 metafile = true
 
 [[files]]
@@ -2148,7 +2148,7 @@ metafile = true
 
 [[files]]
 file = "mods/dark-loading-screen.pw.toml"
-hash = "beaf81b442ffbb5a5ad58f99002631b7f01315520fadfb69e5fcd773ec763011"
+hash = "672389ffd121898ef913c8fdf233a41489feca59e352364b51435561929c5138"
 metafile = true
 
 [[files]]
@@ -2163,7 +2163,7 @@ metafile = true
 
 [[files]]
 file = "mods/default-options-fabric.pw.toml"
-hash = "58a95c791b50243bbaf38e268b2e9c5dff0fb5ad735650cd45f5601c7be5501d"
+hash = "140988cb2b0e7dc1cd7e79c7e513488d816903529038ed37455085525a929502"
 metafile = true
 
 [[files]]
@@ -2173,7 +2173,7 @@ metafile = true
 
 [[files]]
 file = "mods/double-doors.pw.toml"
-hash = "0a3f681afb48c917935b4798bb19267e383fac435a9a61833651c2d2261bf8d6"
+hash = "881e2d3a87072ade2d5adce234cf6c46f2758decc1b9ae0fd2bddf7c10395451"
 metafile = true
 
 [[files]]
@@ -2218,17 +2218,17 @@ metafile = true
 
 [[files]]
 file = "mods/enhanced-celestials-fabric.pw.toml"
-hash = "bc6bc95982d9348589a5b4b1996df017844d3d58d0ca6d2ff27da3ad374a13b5"
+hash = "fdcebc5fa3aa888692ea2ef9ebb268cc7cfb779c22889fbd04db44e0d65cfc5b"
 metafile = true
 
 [[files]]
 file = "mods/entityculling.pw.toml"
-hash = "c2c18bcbc0694dbdc71b1c409c3a598f2ab3e1c65fe9a633fe4a7e9fdd79d573"
+hash = "a0b006553d6862981dc042673b4cdbcaeaab5b48be0e5c81d2522685bc49df4d"
 metafile = true
 
 [[files]]
 file = "mods/equipment-compare-fabric.pw.toml"
-hash = "ad9d9152f6b4db00d6702d1205c841a3b78f8cd58bc87814e68ef61bf3006269"
+hash = "0494ef5f58b955ebc93febb8ae2c685b999005e80ab114f2cf9749bf2244dd1b"
 metafile = true
 
 [[files]]
@@ -2248,7 +2248,7 @@ metafile = true
 
 [[files]]
 file = "mods/extreme-sound-muffler-fabric-official.pw.toml"
-hash = "68c821608eb2fcdcc98ddbd6358d1b31e7d36fbfbc457fb80c31903dc744146f"
+hash = "54d6b50db55f2ea0daccd29352d625dd438da04210c37d447dbabefa90e1099a"
 metafile = true
 
 [[files]]
@@ -2268,7 +2268,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-language-kotlin.pw.toml"
-hash = "e180b1c8800020c8cef0731d9a6f4a2cd6e832e4b961693a69fcd83c584c3b2f"
+hash = "46f5804da77b4cbbd6aac5d361400ad2ef61f5a9a14ff305ba80e8ee6798386d"
 metafile = true
 
 [[files]]
@@ -2283,12 +2283,12 @@ metafile = true
 
 [[files]]
 file = "mods/falling-leaves-fabric.pw.toml"
-hash = "a34160622f04b6431b9adef68ba65b616ff5df8e8f252db8d985be567e154c81"
+hash = "91a9c7b2993d0cb10d71d3eab145fe25801c94f69585c81867be75bde2effc75"
 metafile = true
 
 [[files]]
 file = "mods/fancymenu-fabric.pw.toml"
-hash = "f870eeef5395bfb75498a2075d5e7122574b6313515bb5db5b1144a3591aa6a4"
+hash = "e06c62092d0a14a2ab4252bdc3114e2ffcd298bbf9b002f6f429a40744baf9f6"
 metafile = true
 
 [[files]]
@@ -2368,7 +2368,7 @@ metafile = true
 
 [[files]]
 file = "mods/ftb-ultimine-fabric.pw.toml"
-hash = "f93d5566fdc64e37155f2edab0c5e7147e133b2de1af20c4954c25c2c46203fe"
+hash = "d40a7a1feca365329ba2ad08e42378928b837489cd378763384028ee6c8a59ad"
 metafile = true
 
 [[files]]
@@ -2388,12 +2388,12 @@ metafile = true
 
 [[files]]
 file = "mods/health-overlay-fabric.pw.toml"
-hash = "cb28e27553727aca126af218fae376020706202fd7ef0b94e582e29e004c23a1"
+hash = "1821e2fea7fc0afcdf68af332b46bd1c50fb6787b9bf3b4620244bb6fc3110a9"
 metafile = true
 
 [[files]]
 file = "mods/held-item-info.pw.toml"
-hash = "e58345cfdc6f7f2ee9045f205c8c63f1340d4691fd74b4017eb165f30b128b07"
+hash = "4753656a4f11f33a64cb10349eb4fc9a9998c22e86e1eb59e0e154c1dfe30922"
 metafile = true
 
 [[files]]
@@ -2408,7 +2408,7 @@ metafile = true
 
 [[files]]
 file = "mods/i-know-what-im-doing.pw.toml"
-hash = "008323b6b0ced5b60912b5c149ea6ddbf4270a66cda32f3a69e18fe0a612d5e1"
+hash = "2dab6a0cba397b7ef38eb4838eb2bb59e8d1bd4a721bc22979ce2ff5e89fd831"
 metafile = true
 
 [[files]]
@@ -2418,7 +2418,7 @@ metafile = true
 
 [[files]]
 file = "mods/idwtialsimmoedm.pw.toml"
-hash = "325027a9a59d125c3f0f92f76f72723e16bd22b8b3cf9879af0f556937ac5a1b"
+hash = "fb92cfebec59f40b673bc096ff586a69d205f7aa861406c9df0f02da8efe0c7a"
 metafile = true
 
 [[files]]
@@ -2448,12 +2448,12 @@ metafile = true
 
 [[files]]
 file = "mods/inventory-hud-forge.pw.toml"
-hash = "80e4ca4b9eb0526fd96b72d3ac06063b410e6afef3561dbbaabc6208de448288"
+hash = "0b9b8105e55aac3eedccb41e547caee5c46f9607634e334a94889d06f37ec813"
 metafile = true
 
 [[files]]
 file = "mods/inventory-profiles-next.pw.toml"
-hash = "951822113d628428d173672be47a21b3556abf99415808cd20087dee6101f180"
+hash = "d79711a6d7d2e40c3faeda6e97622d63084dd3900a596dc07d80c74c26699580"
 metafile = true
 
 [[files]]
@@ -2463,7 +2463,7 @@ metafile = true
 
 [[files]]
 file = "mods/ironchests.pw.toml"
-hash = "64ec90954fca86eb006edf2f5aca911cb12b8766863c01e68af97892b327be1b"
+hash = "757f93fdf4fb484ee6b1da0f8fa48a684c0efe98ba146e0f5635b27842ee50d2"
 metafile = true
 
 [[files]]
@@ -2473,7 +2473,7 @@ metafile = true
 
 [[files]]
 file = "mods/item-model-fix.pw.toml"
-hash = "0a1cfd494d57e5723f16d9bd876aa74869f0e8cd12dd216016332e8ff02f7669"
+hash = "fed4003aac208f3ffa7a35efbe47f742eb151ccf54032b67200caa670ec66ab8"
 metafile = true
 
 [[files]]
@@ -2528,7 +2528,7 @@ metafile = true
 
 [[files]]
 file = "mods/lambdynamiclights.pw.toml"
-hash = "b5b6effd63934db82dba3b3d93e095a15df6d46e4d859b2f2e35a425e0c8e82b"
+hash = "c2629d5f23c8625a2f27a54923ae1763906ee2c375e7dd8804793d5bf386ed81"
 metafile = true
 
 [[files]]
@@ -2543,7 +2543,7 @@ metafile = true
 
 [[files]]
 file = "mods/legendary-tooltips-fabric.pw.toml"
-hash = "e189de088332cd4eaf136919a8a6e701d115b378dd73ed39c4f63f3f58e7046a"
+hash = "3803d53ad1b7c8e3cd1a09229238aa5336ef47e60573afc5d0612a60849ab290"
 metafile = true
 
 [[files]]
@@ -2553,7 +2553,7 @@ metafile = true
 
 [[files]]
 file = "mods/libipn.pw.toml"
-hash = "b42d00798b55aaf2b8fb8b4a2c054d64b08b5d9314837df569d40332c9fcaec7"
+hash = "ecae9139dff070573e47cdf60236e93711c162e08775c3a55ee3ca8d614f5d39"
 metafile = true
 
 [[files]]
@@ -2563,7 +2563,7 @@ metafile = true
 
 [[files]]
 file = "mods/light-overlay.pw.toml"
-hash = "b9033df4500968f3c7a758e3e2fbb81fde0bed0ffee0a76cddd099fb76873b30"
+hash = "6c9e4f10b3374dcf3184362552727113b5e0b8b68dd7184e57d5521f6951d5e1"
 metafile = true
 
 [[files]]
@@ -2573,12 +2573,12 @@ metafile = true
 
 [[files]]
 file = "mods/logical-zoom.pw.toml"
-hash = "d4afbb2de460108149970b924b9fa0c60041e1c1df93cfecc8d668de1d91c34f"
+hash = "7736804ad41caff0c0032af47413c3f7336b249e38423f1dde4819581f6604a0"
 metafile = true
 
 [[files]]
 file = "mods/lootr-fabric.pw.toml"
-hash = "2056cbbc69741580c892bcc238ca54ad61f568ba726beb7380c216ef58e17eee"
+hash = "2893c42abb969fb6aafa65da731d4e50d1b02b29377d772f2adf30ea7c512132"
 metafile = true
 
 [[files]]
@@ -2633,7 +2633,7 @@ metafile = true
 
 [[files]]
 file = "mods/modernfix.pw.toml"
-hash = "4dbbc602851815b70a7532b918f98f22b6b3c39c466b3c9c0d589368e4b86091"
+hash = "108789684562a3bea9319a84f4628ce26e3c513a298f3ae464bf416c6a2b8528"
 metafile = true
 
 [[files]]
@@ -2673,7 +2673,7 @@ metafile = true
 
 [[files]]
 file = "mods/not-enough-animations.pw.toml"
-hash = "27794b6dfa33140ddc318fd40c81b3f4747b7c0bcaccb4e440e295741ac54890"
+hash = "43bc0069003473aa92613f57834048665f9840e2a4fbbdf0f0fcc6ac0c1d76a6"
 metafile = true
 
 [[files]]
@@ -2708,7 +2708,7 @@ metafile = true
 
 [[files]]
 file = "mods/pling.pw.toml"
-hash = "40654d1355f8bf07e70eeba00e2ea50b37987a08aa928a8f27445f49f32cc020"
+hash = "149af72bd977de60c6be030ca500a5cd5c82aa85f2f13247484024a1e5ae3887"
 metafile = true
 
 [[files]]
@@ -2728,7 +2728,7 @@ metafile = true
 
 [[files]]
 file = "mods/ponder.pw.toml"
-hash = "2337af3d51b7ce006496ab57e837451198db6058be6ab41ea5aaee5ffd280409"
+hash = "d6208b8a1aa06f658580379a9f9c60c32fe6c29421b07e2dab340a25102b4e77"
 metafile = true
 
 [[files]]
@@ -2748,7 +2748,7 @@ metafile = true
 
 [[files]]
 file = "mods/puzzles-lib.pw.toml"
-hash = "a7a2599342362f2240a4f1fee7f090d9920a3af4c7937fc6237787e7e0aa05d0"
+hash = "4a2878d4176d12d49d4cd3ca19ef85f9bb2a766323bc142697c6d368ec5153fe"
 metafile = true
 
 [[files]]
@@ -2763,17 +2763,17 @@ metafile = true
 
 [[files]]
 file = "mods/raised.pw.toml"
-hash = "200aa9112bfe00b0e192e3fb43c10fd0a3b0602487ed54bbd865ab4dd61900a5"
+hash = "620e0cfc28061bd58846afc3f140e765490d2fa4995ef2c534c4341403268a00"
 metafile = true
 
 [[files]]
 file = "mods/randomblockplacement.pw.toml"
-hash = "551c1458ab8349a4e08120cb199432abf909eed286c3db77d22eae4414dae288"
+hash = "2ffb4b0d6fe032e259d67ff91703ef1e0896cbb672a9865b86fcbba7557d2244"
 metafile = true
 
 [[files]]
 file = "mods/reacharound.pw.toml"
-hash = "7095bd44c88f260ae5af76ea31c41972b855e2f9a2766bf00c88a19ee409c6c4"
+hash = "b875118ef3666c30dd07bf1a87cd7457bc8d43d2aa97e8e701e162a5f0e77d38"
 metafile = true
 
 [[files]]
@@ -2858,7 +2858,7 @@ metafile = true
 
 [[files]]
 file = "mods/selene.pw.toml"
-hash = "1e1bda41b44d7433e7d8287e2d43da5e32715e9c2e5bc1de1277a47ada38db55"
+hash = "da3a6cc0aed92ce548d5495be09e45956bab12e69a8536f6551c732cbdf4ea69"
 metafile = true
 
 [[files]]
@@ -2868,12 +2868,12 @@ metafile = true
 
 [[files]]
 file = "mods/simple-discord-rich-presence.pw.toml"
-hash = "604fb0b215e9c6e01f7a2aea7490cf3c00258922f13a21910e082acf43bca315"
+hash = "605ff5ed4987eb9bcdc181cef7e37fa1ab57897e871795d61c26ead91d62c960"
 metafile = true
 
 [[files]]
 file = "mods/simple-voice-chat.pw.toml"
-hash = "ebab8c5a4fadb79217c8eb6485a5a7375a7bd641ed83fae175403696390b4a54"
+hash = "1036f1ae7946e6769d0ff803e0bebe3e27f8f0b1e99921669906d39980db39d0"
 metafile = true
 
 [[files]]
@@ -2883,7 +2883,7 @@ metafile = true
 
 [[files]]
 file = "mods/skin-layers-3d.pw.toml"
-hash = "18837ce2e2f6aee65bb5714b52194efb415b6f2a9cbf57a142f5d723f0a0ec8f"
+hash = "2fa119272f457df09b2b2888c3dc23c6e3f5491d33d054996c3720db0b78e6dc"
 metafile = true
 
 [[files]]
@@ -2968,12 +2968,12 @@ metafile = true
 
 [[files]]
 file = "mods/structory-towers.pw.toml"
-hash = "0dce7ce32df160cc032fee249f8b85f8d1ed21f8ab0903531c3c8ba5fd19eccc"
+hash = "48268ac0e9b8ca2b495d30d48733be4cc33e79fc1601e001b358525655843230"
 metafile = true
 
 [[files]]
 file = "mods/structory.pw.toml"
-hash = "d4acddd9dbe8063560fa281eb07898471841df72832e6068015cb742928f2e90"
+hash = "0ac60475f877d019e8d77e4d3241f39e395ccce21b191a999f279fe566e7e9f2"
 metafile = true
 
 [[files]]
@@ -2983,7 +2983,7 @@ metafile = true
 
 [[files]]
 file = "mods/supplementaries.pw.toml"
-hash = "6ae2cd1b20a1685be405e052f3c00e6fb9c21454463ea04c1037dd548a098c80"
+hash = "308781a3b29419dcd8c0aeb2365fa433f77c6cc3a55270e3685965302ac7fd57"
 metafile = true
 
 [[files]]
@@ -2993,7 +2993,7 @@ metafile = true
 
 [[files]]
 file = "mods/terrablender-fabric.pw.toml"
-hash = "6609d4f430acb8d486583759dbe8313904ccb839b0ef073a97030c89f43c2907"
+hash = "a702ea2764c693ea611e64a42ddac1d8232b5861cba9d77fb008e11af8670e5c"
 metafile = true
 
 [[files]]
@@ -3008,7 +3008,7 @@ metafile = true
 
 [[files]]
 file = "mods/tipthescales.pw.toml"
-hash = "dbfc93c70494a03ace7372add3e978ecd7227cdbdbc5b986e8c0f6332a732817"
+hash = "5b585952c40efd4d02de934464bb7ede6c3167ca0069cb564930bbc4d534353f"
 metafile = true
 
 [[files]]
@@ -3023,7 +3023,7 @@ metafile = true
 
 [[files]]
 file = "mods/tool-stats.pw.toml"
-hash = "ac932722fb344ffbac305b6310c8e4e0f92b40db7e5fb2bddedb3e8d3608a771"
+hash = "31982f9609b55b8abdb06b6eb92f4f53991634e27064555d077cc44c1c5847b8"
 metafile = true
 
 [[files]]
@@ -3058,7 +3058,7 @@ metafile = true
 
 [[files]]
 file = "mods/visuality.pw.toml"
-hash = "33a134f906ecd42fc2e5c424ec1e6335e23c4f02fcd615681199b8c9dda83f9d"
+hash = "2aa30c91f597210bc48ef8ee1d23df7eb13e1b2b9a7841b80a909306b5c1a59e"
 metafile = true
 
 [[files]]
@@ -3068,7 +3068,7 @@ metafile = true
 
 [[files]]
 file = "mods/waveycapes.pw.toml"
-hash = "830be7851fd9ceb3d791f03e98ea658c34773ef50af6f3eeb47cbb7810e39743"
+hash = "8c0ee55069cd26d43455e6c95fa9269888fe254e659ddc9037dae698d1330a7c"
 metafile = true
 
 [[files]]
@@ -3078,7 +3078,7 @@ metafile = true
 
 [[files]]
 file = "mods/when-dungeons-arise-fabric.pw.toml"
-hash = "4f6288b514a60ff79903a096d453c6d2b6e3539cadf6af771e0f6eb5be734471"
+hash = "04127f5553cf31117d49248b50ff2b14e0f91aeb599d34ae1b11b1682afab78c"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -1968,7 +1968,7 @@ metafile = true
 
 [[files]]
 file = "mods/building-wands.pw.toml"
-hash = "4586e513829cc60eb90bcd680f4fe75fc85f104ce68f741cd15a09202ddeb504"
+hash = "9a66fb062f4b349bd5dd3058f3654ee2ee607f53ec665c9341dbfd83913e5254"
 metafile = true
 
 [[files]]
@@ -2243,7 +2243,7 @@ metafile = true
 
 [[files]]
 file = "mods/extended-drawers.pw.toml"
-hash = "98563983edf0c0a4d832bd9eedcb0ef3f6e396c634d2fa05a6476752a574544e"
+hash = "d0c065ccb94e1164816f5143b58ef5cd22087e1933d2ade14fb35ea7ee7eec93"
 metafile = true
 
 [[files]]
@@ -2348,7 +2348,7 @@ metafile = true
 
 [[files]]
 file = "mods/ftb-essentials-forge.pw.toml"
-hash = "32b2ad43481e44768f395c26bb3e062202a84424294a500e65e5f6ed64537871"
+hash = "12d45fd4c264c6b624e6b9a60a7ec4040e294498eb32998bc401d406d2617b07"
 metafile = true
 
 [[files]]
@@ -2943,7 +2943,7 @@ metafile = true
 
 [[files]]
 file = "mods/spellblade-next.pw.toml"
-hash = "4385d19f720f87b805767066dd6d669fed58de82ee5f00901d1e304b614ec0d5"
+hash = "35e5e3dba089c7a2a20aaf6c7edeade94b1ebfc781343ec8a4855486eb507350"
 metafile = true
 
 [[files]]

--- a/kubejs/server_scripts/mi_replicatorblacklist.js
+++ b/kubejs/server_scripts/mi_replicatorblacklist.js
@@ -9,6 +9,7 @@ ServerEvents.tags('item', e => {
     let ic = (id) => `ironchests:${id}`;
     let cr = (id) => `create:${id}`;
     let sp = (id) => `spectrum:${id}`;
+    let ed = (id) => `extended_drawers:${id}`;
 
     const ITEMS = [
         'kibe:tank',
@@ -143,7 +144,13 @@ ServerEvents.tags('item', e => {
         tr('quantum_helmet'),
         tr('quantum_chestplate'),
         tr('quantum_leggings'),
-        tr('quantum_boots')
+        tr('quantum_boots'),
+	ed('single_drawer'),
+	ed('double_drawer'),
+	ed('quad_drawer'),
+	ed('shadow_drawer'),
+	ed('compacting_drawer'),
+	'quarrymod:quarry'
     ];
 
     ITEMS.forEach(id => e.add(mi('replicator_blacklist'), id));

--- a/mods/building-wands.pw.toml
+++ b/mods/building-wands.pw.toml
@@ -1,13 +1,13 @@
 name = "Building Wands"
-filename = "BuildingWands-mc1.19.2-2.6.6-release-fabric.jar"
+filename = "BuildingWands-mc1.19.2-2.6.7-release-fabric.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "f1c32abcecb0f0f5e94185597ab5a1a0f825d6cb"
+hash = "efc45a57b9b4d496cc046bec85ec610b91ff7fac"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4475409
+file-id = 4610017
 project-id = 363392

--- a/mods/extended-drawers.pw.toml
+++ b/mods/extended-drawers.pw.toml
@@ -1,13 +1,13 @@
 name = "Extended Drawers"
-filename = "ExtendedDrawers-1.4.2+mc.1.19.2.jar"
+filename = "ExtendedDrawers-1.4.3+mc.1.19.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "0ad145ca031ebbfbaac34101b7dfc266a017aba6"
+hash = "e943a36b75af4368c0e82dd707997bda67ad46d4"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4608466
+file-id = 4610363
 project-id = 616602

--- a/mods/ftb-essentials-forge.pw.toml
+++ b/mods/ftb-essentials-forge.pw.toml
@@ -1,13 +1,13 @@
 name = "FTB Essentials (Forge)"
-filename = "ftb-essentials-fabric-1902.3.2-build.85.jar"
+filename = "ftb-essentials-fabric-1902.3.3-build.100.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "caef3767c0f2de66a99582c1df5e1460d374d8b1"
+hash = "ce7ac748ee7f40b9661ea14f46ae1fcdaf58de3c"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4584229
+file-id = 4610351
 project-id = 410811

--- a/mods/spellblade-next.pw.toml
+++ b/mods/spellblade-next.pw.toml
@@ -1,13 +1,13 @@
 name = "Spellblades and Such"
-filename = "spellbladenext-fabric-1.0.26.1.hotfix1.jar"
+filename = "spellbladenext-fabric-1.0.26.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "b7dbda7ac08c2221a33f8b37a6072f637b0ddb25"
+hash = "5438f64da01c23a8eca0c94ea982abee53632932"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4602962
+file-id = 4610059
 project-id = 811662

--- a/pack.toml
+++ b/pack.toml
@@ -1,12 +1,12 @@
 name = "StaTech Industry"
 author = "static"
-version = "1.0.5"
+version = "1.0.5hotfix"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "e5f6140380933a738c75847bb6c117044bf84d85b75a4e6f2a2f0e9a6967f138"
+hash = "e13c5b8f56f8ba46cd0b86e1c42bc839928ecd0d172e68c9d507940e12112410"
 
 [versions]
 fabric = "0.14.21"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "9639dc0406ef218968326b5f7be2fc92d7837a3d489e59ba0a83007da7387976"
+hash = "e5f6140380933a738c75847bb6c117044bf84d85b75a4e6f2a2f0e9a6967f138"
 
 [versions]
 fabric = "0.14.21"


### PR DESCRIPTION
# StaTech Industry 1.0.5hotfix changelog:
This is a hotfix to update the ExtendedDrawers mod as the last version to ship with 1.0.5 had some critical issues with compacting drawers, and has been addressed by the mod author. Apologies if this has negatively impacted your world.

## Mods updated:
- [Building Wands](https://www.curseforge.com/minecraft/mc-mods/building-wands) 2.6.6 -> 2.6.7
- [ExtendedDrawers](https://www.curseforge.com/minecraft/mc-mods/extended-drawers) 1.4.2 -> 1.4.3
- [FTB Essentials](https://www.curseforge.com/minecraft/mc-mods/ftb-essentials-forge) 1902.3.2-build.85 -> 1902.3.3-build.100
- [Spellblades and such](https://www.curseforge.com/minecraft/mc-mods/spellblade-next) 1.0.26.1.hotfix1 -> 1.0.26.2

## Other changes:
- [Updated MI replicator blacklist](https://github.com/TheStaticVoid/StaTech-Industry/commit/03a54222c34b29dd2f41187bd1c912ee8b1404f9)