### PR TITLE
1.1.2 -> Main

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,13 @@
+StaTech Industry 1.1.2 Changelog:
+
+This is a hotfix for a critical issue related to Nether Geocluster deposits introduced in the last patch.
+
+Mod updates:
+- [FTB Quests](https://www.curseforge.com/minecraft/mc-mods/ftb-quests-fabric) - 1902.5.1-build.250 -> 1902.5.2-build.256
+- [FTB XMod Compat](https://www.curseforge.com/minecraft/mc-mods/ftb-xmod-compat) - 1.2.0 -> 1.2.1
+- [Spellblades and such](https://www.curseforge.com/minecraft/mc-mods/spellblade-next) - 1.0.27.1.3 -> 1.0.27.1.4
+- [Reese's Sodium Options](https://www.curseforge.com/minecraft/mc-mods/reeses-sodium-options) - 1.4.9 -> 1.6.0
+
+Other changes:
+- [Fixed crash related to Nether geocluster deposits](https://github.com/TheStaticVoid/StaTech-Industry/issues/285)
+- [Fixed misleading subtitle on Steam Mining Drill quest](https://github.com/TheStaticVoid/StaTech-Industry/issues/284)

--- a/config/ftbquests/quests/chapters/2__the_steam_age.snbt
+++ b/config/ftbquests/quests/chapters/2__the_steam_age.snbt
@@ -69,7 +69,7 @@
 			]
 			shape: "rsquare"
 			size: 1.5d
-			subtitle: "3x3 with Silk Touch/Fortune"
+			subtitle: "3x3 with Silk Touch"
 			tasks: [{
 				id: "36E79689C51B2EC4"
 				item: "modern_industrialization:steam_mining_drill"

--- a/index.toml
+++ b/index.toml
@@ -2664,7 +2664,7 @@ metafile = true
 
 [[files]]
 file = "mods/ftb-quests-fabric.pw.toml"
-hash = "8ac14f2cdf5a3f05791d6e5f3740be1097f5845cde9d2dfb8cf25ca2edca3986"
+hash = "66a8a8cd1c3729335d2a7a2f2cea040f39045f44d1d85912821cce73f488e3d2"
 metafile = true
 
 [[files]]
@@ -2674,7 +2674,7 @@ metafile = true
 
 [[files]]
 file = "mods/ftb-xmod-compat.pw.toml"
-hash = "cf954828417adc69250ce02131a3f033fb57c172b5ceed183c4b2c48a834f13b"
+hash = "aee72847017e96821a2b82bf04c0aa5b85e2becd67dccea2e5514798c3ea5f0c"
 metafile = true
 
 [[files]]
@@ -3059,7 +3059,7 @@ metafile = true
 
 [[files]]
 file = "mods/reeses-sodium-options.pw.toml"
-hash = "44a47f74ec7613ff265084e9207d3346ee110e1d2448db17c16e60ccbdb40261"
+hash = "a71c4ed70ba942704c528c41c30d19ebcf018a6e1ade25b19558566c0643d213"
 metafile = true
 
 [[files]]
@@ -3214,7 +3214,7 @@ metafile = true
 
 [[files]]
 file = "mods/spellblade-next.pw.toml"
-hash = "8462ca9d13f039b02dae556fbf39558d7ee8167c55eddcfd56a80cb058e302fe"
+hash = "efcbcf07900ac2cca8a02ae2615af604fd53bd564fa0aeecb701f82ead24219a"
 metafile = true
 
 [[files]]

--- a/kubejs/data/geocluster/deposits/techreborn_nether.json
+++ b/kubejs/data/geocluster/deposits/techreborn_nether.json
@@ -37,7 +37,7 @@
         },
         "samples": [
             {
-                "block": "geocluster:pyrite_ore_sample",
+                "block": "kubejs:pyrite_ore_sample",
                 "chance": 1.0
             }
         ]

--- a/mods/ftb-quests-fabric.pw.toml
+++ b/mods/ftb-quests-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "FTB Quests (Fabric)"
-filename = "ftb-quests-fabric-1902.5.1-build.250.jar"
+filename = "ftb-quests-fabric-1902.5.2-build.256.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "df5837403893e60db8ad03fcdc7a107301b898bb"
+hash = "d4bdbb9a96e0e81219445338ac482a59e2d8834d"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4652999
+file-id = 4665127
 project-id = 438496

--- a/mods/ftb-xmod-compat.pw.toml
+++ b/mods/ftb-xmod-compat.pw.toml
@@ -1,13 +1,13 @@
 name = "FTB XMod Compat"
-filename = "ftb-xmod-compat-fabric-1.2.0.jar"
+filename = "ftb-xmod-compat-fabric-1.2.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "21d840e69710b277a8f85ede967f7f94bc5f1b5c"
+hash = "8697fb7bbb37a69b97cc07584ab29d5f172368ae"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4663324
+file-id = 4665136
 project-id = 889915

--- a/mods/reeses-sodium-options.pw.toml
+++ b/mods/reeses-sodium-options.pw.toml
@@ -1,13 +1,13 @@
 name = "Reese's Sodium Options"
-filename = "reeses_sodium_options-1.4.9+mc1.19.2-build.67.jar"
+filename = "reeses_sodium_options-1.6.0+mc1.19.2-build.78.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "3b48ed460ce30c38e6058fdd0c3d6a221913e4e4"
+hash = "9da83d3e073373cd4bb9b3906a7627e481aa303a"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4126247
+file-id = 4664573
 project-id = 511319

--- a/mods/spellblade-next.pw.toml
+++ b/mods/spellblade-next.pw.toml
@@ -1,13 +1,13 @@
 name = "Spellblades and Such"
-filename = "spellbladenext-fabric-1.0.27.1.3.jar"
+filename = "spellbladenext-fabric-1.0.27.1.4.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "60c21129f5fd5555a2503f6f48ac36a27fdf1b01"
+hash = "f8d899231281763b5471f769c14c1f470ee6d945"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4652764
+file-id = 4664366
 project-id = 811662

--- a/pack.toml
+++ b/pack.toml
@@ -1,12 +1,12 @@
 name = "StaTech Industry"
 author = "static"
-version = "1.1.1"
+version = "1.1.2"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0f631ae70afe204aac61f92b6473e532a3d0d60942e10d70701866f9a5efddc3"
+hash = "d4a942cb18f1f1fb81044030e0b5a0b2cd846336e579f468a19866ae2be35894"
 
 [versions]
 fabric = "0.14.21"


### PR DESCRIPTION
# StaTech Industry 1.1.2 Changelog:

This is a hotfix for a critical issue related to Nether Geocluster deposits introduced in the last patch.

## Mod updates:
- [FTB Quests](https://www.curseforge.com/minecraft/mc-mods/ftb-quests-fabric) - 1902.5.1-build.250 -> 1902.5.2-build.256
- [FTB XMod Compat](https://www.curseforge.com/minecraft/mc-mods/ftb-xmod-compat) - 1.2.0 -> 1.2.1
- [Spellblades and such](https://www.curseforge.com/minecraft/mc-mods/spellblade-next) - 1.0.27.1.3 -> 1.0.27.1.4
- [Reese's Sodium Options](https://www.curseforge.com/minecraft/mc-mods/reeses-sodium-options) - 1.4.9 -> 1.6.0

## Other changes:
- [Fixed crash related to Nether geocluster deposits](https://github.com/TheStaticVoid/StaTech-Industry/issues/285)
- [Fixed misleading subtitle on Steam Mining Drill quest](https://github.com/TheStaticVoid/StaTech-Industry/issues/284)