### PR TITLE
Whitelist lootr in claims

### DIFF
--- a/kubejs/server_scripts/claim_interact_whitelist.js
+++ b/kubejs/server_scripts/claim_interact_whitelist.js
@@ -1,0 +1,4 @@
+onEvent('block.tags', (event) => {
+    const blocks = [/lootr:lootr_\w+/];
+    event.get('ftbchunks:interact_whitelist').add(blocks);
+});

--- a/kubejs/server_scripts/claim_interact_whitelist.js
+++ b/kubejs/server_scripts/claim_interact_whitelist.js
@@ -1,4 +1,4 @@
-onEvent('block.tags', (event) => {
-    const blocks = [/lootr:lootr_\w+/];
-    event.get('ftbchunks:interact_whitelist').add(blocks);
+ServerEvents.tags('block', (event) => {
+    const blocks = /lootr:lootr_\w+/;
+    event.add('ftbchunks:interact_whitelist', blocks);
 });


### PR DESCRIPTION
Whitelist `lootr` chests/barrels/shulkers so they can be used even if they are inside a claim.

Code copied from https://github.com/EnigmaticaModpacks/Enigmatica6/pull/5177/files
(sharestones already have the tag)