### PR TITLE
1.1.5hotfix -> main

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,47 +1,6 @@
-# StaTech Industry 1.1.5 Changelog:
+# StaTech Industry 1.1.5hotfix Changelog:
 
-This is a QoL update to the pack, including some new mods to lessen some of the headaches from vanilla, reintroducing Megane to avoid errors being spammed in your chat, Redirectionor for increased memory performance, and Enhanced Workbenches which add some very useful early game crafting tables to the game. Additionally, redcatone went through and fixed my many spelling mistakes and I've fixed a couple quests that were missing description or had incorrect requirements.
+Hotfix patch downgrading the Guard Villagers version due to server crashes on startup.
 
-## Mods added:
-- [Enhanced Workbenches](https://www.curseforge.com/minecraft/mc-mods/enhanced-workbenches) - Based developer backported to 1.19.2
-- [Low Fire](https://www.curseforge.com/minecraft/mc-mods/low-fire) - Lowers the view of fire in first person as to not block 50%+ of the screen
-- [Megane](https://www.curseforge.com/minecraft/mc-mods/megane) - Needed for Kibe storage containers to not throw an error with WTHIT
-- [No Recipe Book](https://www.curseforge.com/minecraft/mc-mods/norecipebook-fabric) - Removes the recipe book from showing in the crafting table and other UIs
-- [Redirectionor](https://www.curseforge.com/minecraft/mc-mods/redirectionor) - Reduces memory cost of the game by changing usages of enums
-- [Superflat World No Slimes](https://www.curseforge.com/minecraft/mc-mods/superflat-world-no-slimes) - Utility mod that removes slime spawning from super flat worlds. They're so annoying.
-- [Toast Manager](https://www.curseforge.com/minecraft/mc-mods/toast-manager) - Hides vanilla recipe book and tutorials toasts
-
-## Mods removed:
-- [I know what I'm doing](https://www.curseforge.com/minecraft/mc-mods/i-know-what-im-doing) - Replaced by Toast Manager
-
-## Mods updated:
-- [Complementary Reimagined](https://modrinth.com/shader/complementary-reimagined) - 2.2.1 -> 2.3
-- [Default Options](https://www.curseforge.com/minecraft/mc-mods/default-options-fabric) - 15.0.1 -> 15.0.2
-- [Guard Villagers](https://www.curseforge.com/minecraft/mc-mods/guard-villagers-fabric) 1.1.2 -> 2.0.5
-- [KubeJS](https://www.curseforge.com/minecraft/mc-mods/kubejs) - 1902.6.1-build.337 -> 1902.6.1-build.352
-- [ModernFix](https://www.curseforge.com/minecraft/mc-mods/modernfix) - 5.4.1 -> 5.5.1
-- [Spice of Fabric](https://www.curseforge.com/minecraft/mc-mods/spice-of-fabric) - 1.6.0-beta -> 1.6.1
-- [Tech-enhanced](https://www.curseforge.com/minecraft/mc-mods/tech-enhanced) - 1.0.5 -> 1.0.6
-- [WTHIT](https://www.curseforge.com/minecraft/mc-mods/wthit) - 5.17.0 -> 5.18.0
-
-## Other changes:
-- Updated to Fabric 0.14.22
-- REI settings should no longer reset with this update!
-- [Quest Typos fix by redcatone](https://github.com/TheStaticVoid/StaTech-Industry/pull/342)
-- [Allow for Lootr chests to be opened in claimed chunks by redcatone](https://github.com/TheStaticVoid/StaTech-Industry/pull/350)
-- [Fix invar block recipe in alloy smelter](https://github.com/TheStaticVoid/StaTech-Industry/issues/337)
-- [Fix spectrum saplings not being a chance output](https://github.com/TheStaticVoid/StaTech-Industry/issues/340)
-- [Add TrollDespair to Emojiful](https://github.com/TheStaticVoid/StaTech-Industry/issues/347)
-- [Add Marble macerator recipe](https://github.com/TheStaticVoid/StaTech-Industry/issues/344)
-- [Added quest description for obtaining Budding Certus](https://github.com/TheStaticVoid/StaTech-Industry/issues/336)
-- [Added quest description for Brass Casing](https://github.com/TheStaticVoid/StaTech-Industry/issues/338)
-- [Fix Calorite Machine Casing requirement for Core Mining Drill quest](https://github.com/TheStaticVoid/StaTech-Industry/issues/339)
-- [Update Liquid Crystal quest to detail you need to step in the fluid](https://github.com/TheStaticVoid/StaTech-Industry/issues/343)
-- [Fix quest requirements for Spectrum Enchanter and Cinderhearth](https://github.com/TheStaticVoid/StaTech-Industry/issues/345)
-- [Blacklist IPN from Kibe Cooler and Tom's Level Emitter](https://github.com/TheStaticVoid/StaTech-Industry/issues/349)
-- [Disabled Megane's modules for Create and MI](https://github.com/TheStaticVoid/StaTech-Industry/commit/f277e1f8e44bd875f64f83f5a7404d3a3154ce77)
-- [Update Blaze Model to require lava](https://github.com/TheStaticVoid/StaTech-Industry/commit/2aec361e6f03ea4024d3fde7161fccfeb66e9db6)
-- [Update Ghast and Piglin models to also require lava](https://github.com/TheStaticVoid/StaTech-Industry/commit/e3e57d3946c2ade5c98b6cc16865e4d8bca30ec2)
-
-## First-time Contributors
-- redcatone
+## Mods downgraded:
+- [Guard Villagers](https://www.curseforge.com/minecraft/mc-mods/guard-villagers-fabric) 2.0.5 -> 1.1.2

--- a/index.toml
+++ b/index.toml
@@ -2844,7 +2844,7 @@ metafile = true
 
 [[files]]
 file = "mods/guard-villagers-fabric.pw.toml"
-hash = "1b73cf04017b2809c6b7140c0b9dce8037e5856568b1186204ed15ed1ee23676"
+hash = "d42b3565f574b9057173fc6f2d9b88998b4b55a7310538343488c3fe9844cf6b"
 metafile = true
 
 [[files]]

--- a/mods/guard-villagers-fabric.pw.toml
+++ b/mods/guard-villagers-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Guard Villagers (Fabric/Quilt)"
-filename = "guardvillagers-2.0.5-1.19.2.jar"
+filename = "guard-villagers-fabric-1.19.2-1.1.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "977d7d1959ca078cb16a9adb29c158b373f0c083"
+hash = "b69144c72c9c8ccfb16dcd0a1e6f6b2711342fd4"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4682642
+file-id = 4483298
 project-id = 571503

--- a/pack.toml
+++ b/pack.toml
@@ -1,12 +1,12 @@
 name = "StaTech Industry"
 author = "static"
-version = "1.1.5"
+version = "1.1.5hotfix"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "d4dcbb3521e27ac0c042a1ff8766b058fe26a08b5bad2b0c37642cc82a748304"
+hash = "aff1a6a9a1fbbeae119c33a6e341d7038ffb8d3cf8b59d1cd7441990896fb9b1"
 
 [versions]
 fabric = "0.14.22"


### PR DESCRIPTION
# StaTech Industry 1.1.5hotfix Changelog:

Hotfix patch downgrading the Guard Villagers version due to server crashes on startup.

## Mods downgraded:
- [Guard Villagers](https://www.curseforge.com/minecraft/mc-mods/guard-villagers-fabric) 2.0.5 -> 1.1.2