### PR TITLE
Update 3__electrical_age.snbt

### DIFF
--- a/config/ftbquests/quests/chapters/3__electrical_age.snbt
+++ b/config/ftbquests/quests/chapters/3__electrical_age.snbt
@@ -67,7 +67,7 @@
 				""
 				"The &aSteam Turbine&r will automatically send electricity to any machine connected directly &dto its output side&r. &eIt will only connect to cables placed on its output side&r. It has the Low Voltage (LV) Tier."
 				""
-				"Every electric cable has a &6Tier&r which determines how many &eEU/t&r it can transfer and which machines it can connect to. &3Copper, Silver, and Tin are LV&r, &2Curponickel and Electrum are MV&r, and so on..."
+				"Every electric cable has a &6Tier&r which determines how many &eEU/t&r it can transfer and which machines it can connect to. &3Copper, Silver, and Tin are LV&r, &2Cupronickel and Electrum are MV&r, and so on..."
 				""
 				"Cable networks have limitations on the amount of energy they will pull into the network: at most &3256 EU/t for LV cables&r, &21024 EU/t for MV cables&r and &d8192 EU/t for HV cables&r. Because there is no output limit for the network and because cables have a small internal storage, an LV network can provide more than 256 EU/t for a &oshort&r amount of time."
 				""


### PR DESCRIPTION
Fixed spelling of Cupronickel