### PR TITLE
1.1.13 -> main

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,3 +19,4 @@ Another maintenance patch. Notably this brings the new Create update that fixes 
 ## Other changes:
 - Completionist cape list updates
 - [Fix missing netherite wand recipe](https://github.com/TheStaticVoid/StaTech-Industry/issues/478)
+- [Added quest for the Redstone Control Module](https://github.com/TheStaticVoid/StaTech-Industry/commit/6a82a48b3a1adc86e51b4776e5818ccdea5c2663)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,97 +1,20 @@
-# StaTech Industry 1.1.12 Changelog:
-This is primarily a maintenance patch as we wait for 1.21 and the NeoForge jump for version 1.2.0 (or 2.0, not sure on name yet). This patch will bring the update to Modern Industrialization that brings redstone control to your machines, as well as many other mod updates.
+# StaTech Industry 1.1.13 Changelog:
+Another maintenance patch. Notably this brings the new Create update that fixes the crash-to-desktop when viewing certain Create recipes.
 
 ## Mods updated:
-- [Almost Unified](https://www.curseforge.com/minecraft/mc-mods/almost-unified) - 0.7.0 -> 0.8.1
-- [AttributeFix](https://www.curseforge.com/minecraft/mc-mods/attributefix) - 17.2.7 -> 17.2.8
-- [AppleSkin](https://www.curseforge.com/minecraft/mc-mods/appleskin) - 2.4.1 -> 2.5.1
-- [Applied Energistics 2](https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2) - 12.9.8 -> 12.9.9
-- [Applied Energistics 2 Wireless Terminals](https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2-wireless-terminals) - 12.9.5 -> 12.9.8
-- [Architectury API](https://www.curseforge.com/minecraft/mc-mods/architectury-api) - 6.5.85 -> 6.6.92
-- [bad packets](https://www.curseforge.com/minecraft/mc-mods/badpackets) - 0.2.1 -> 0.2.3
-- [Better FPS](https://www.curseforge.com/minecraft/mc-mods/better-fps-render-distance) - 2.4 -> 4.2
-- [Botarium](https://www.curseforge.com/minecraft/mc-mods/botarium) - 1.8.2 -> 1.9.2
-- [Building Wands](https://www.curseforge.com/minecraft/mc-mods/building-wands) - 2.6.8 -> 2.6.9
-- [Carry On](https://www.curseforge.com/minecraft/mc-mods/carry-on) - 2.1.1.21 -> 2.1.2.23
-- [Chat Heads](https://www.curseforge.com/minecraft/mc-mods/chat-heads) - 0.10.22 -> 0.10.31
-- [ChoiceTheorem's Overhauled Village](https://www.curseforge.com/minecraft/mc-mods/choicetheorems-overhauled-village) - 3.2.5 -> 3.2.6c
-- [Cloth Config API](https://www.curseforge.com/minecraft/mc-mods/cloth-config) - 8.3.103 -> 8.3.115
-- [Complementary Reimagined](https://modrinth.com/shader/complementary-reimagined) - 5.0.1 -> 5.1.1
-- [Crafting Tweaks](https://www.curseforge.com/minecraft/mc-mods/crafting-tweaks-fabric) - 15.1.8 -> 15.1.9
-- [Create](https://www.curseforge.com/minecraft/mc-mods/create-fabric) - 0.5.1-c-build.1160 -> 0.5.1-f-build.1334
-- [Create: Crafts & Additions](https://www.curseforge.com/minecraft/mc-mods/createaddition) - 20230723a -> 1.2.3
-- [Create: Steam 'n' Rails](https://www.curseforge.com/minecraft/mc-mods/create-steam-n-rails) - 1.5.1 -> 1.5.3
-- [Collective](https://www.curseforge.com/minecraft/mc-mods/collective) - 6.66 -> 7.39
-- [Cupboard](https://www.curseforge.com/minecraft/mc-mods/cupboard) - 2.0.0 -> 2.6.0
-- [Dank Storage](https://www.curseforge.com/minecraft/mc-mods/dank-storage-fabric) - 4.3.0 -> 4.4.0
-- [Emojiful](https://www.curseforge.com/minecraft/mc-mods/emojiful) - 4.0.4 -> 4.0.5
-- [Extended Drawers](https://www.curseforge.com/minecraft/mc-mods/extended-drawers) - 1.4.3 -> 1.4.5
-- [Extreme Sound Muffler](https://www.curseforge.com/minecraft/mc-mods/extreme-sound-muffler) - 3.38 -> 3.39
-- [Fabric API](https://www.curseforge.com/minecraft/mc-mods/fabric-api) - 0.76.1 -> 0.77.0
-- [Fabric Language Kotlin](https://www.curseforge.com/minecraft/mc-mods/fabric-language-kotlin) - 1.9.10 -> 1.9.23
-- [FancyMenu](https://www.curseforge.com/minecraft/mc-mods/fancymenu) - 2.14.9 -> 2.14.14
-- [Farmer's Delight](https://www.curseforge.com/minecraft/mc-mods/farmers-delight) - 1.3.10.1 -> 1.3.10.2
-- [FTB Backups 2](https://www.curseforge.com/minecraft/mc-mods/ftb-backups-2) - 1.0.22 -> 1.0.23
-- [FTB Chunks](https://www.curseforge.com/minecraft/mc-mods/ftb-chunks-fabric) - 1902.4.2-build.302 -> 1902.4.4-build.326
-- [FTB Essentials](https://www.curseforge.com/minecraft/mc-mods/ftb-essentials-forge) - 1902.3.3-build.100 -> 1902.3.5-build.120
-- [FTB Quests](https://www.curseforge.com/minecraft/mc-mods/ftb-quests-fabric) - 1902.5.5-build.297 -> 1902.5.8-build.345
-- [FTB XMod Compat](https://www.curseforge.com/minecraft/mc-mods/ftb-xmod-compat) - 1.2.2 -> 1.2.3
-- [Guard Villagers](https://www.curseforge.com/minecraft/mc-mods/guard-villagers-fabric) - 2.0.6 -> 2.0.7
-- [Inventory Profiles Next](https://www.curseforge.com/minecraft/mc-mods/inventory-profiles-next) - 1.10.7 -> 1.10.9
-- [Iris](https://modrinth.com/mod/iris) - 1.6.9 -> 1.6.11
-- [JourneyMap](https://www.curseforge.com/minecraft/mc-mods/journeymap) - 5.9.7 -> 5.9.7p1
-- [Just Enough Calculation](https://www.curseforge.com/minecraft/mc-mods/just-enough-calculation) - 4.0.3 -> 4.0.4
-- [Konkrete](https://www.curseforge.com/minecraft/mc-mods/konkrete-fabric) - 1.6.1 -> 1.8.0
-- [KubeJS](https://www.curseforge.com/minecraft/mc-mods/kubejs) - 1902.6.1-build.370 -> 1902.6.2-build.63
-- [LibIPN](https://www.curseforge.com/minecraft/mc-mods/libipn) - 4.0.0 -> 4.0.1
-- [Lootr](https://www.curseforge.com/minecraft/mc-mods/lootr-fabric) 0.4.27.67 -> 0.4.28.69
-- [Macaw's Paintings](https://www.curseforge.com/minecraft/mc-mods/macaws-paintings) - 1.0.4 -> 1.0.5
-- [megane](https://www.curseforge.com/minecraft/mc-mods/megane) - 8.6.0 -> 19.2.2
-- [ModernFix](https://www.curseforge.com/minecraft/mc-mods/modernfix) - 5.7.4 -> 5.14.0
-- [Modern Industrialization](https://www.curseforge.com/minecraft/mc-mods/modern-industrialization) - 1.6.16 -> 1.6.18
-- [Modern Industrialization Sound Addon](https://www.curseforge.com/minecraft/mc-mods/modern-industrialization-sound-addon) - 1.0.1 -> 1.0.2
-- [Moonlight Lib](https://www.curseforge.com/minecraft/mc-mods/selene) - 2.2.45 -> 2.3.6
-- [Naturalist](https://www.curseforge.com/minecraft/mc-mods/naturalist) - 3.0.4 -> 4.0.3
-- [Not Enough Animations](https://www.curseforge.com/minecraft/mc-mods/not-enough-animations) - 1.6.2 -> 1.7.1
-- [Oh the Biomes You'll Go](https://www.curseforge.com/minecraft/mc-mods/oh-the-biomes-youll-go-fabric) - 2.0.1.4 -> 2.0.1.6
-- [Passive Shield](https://www.curseforge.com/minecraft/mc-mods/passive-shield) - 3.2.0 -> 3.4.0
-- [Peripheralium](https://www.curseforge.com/minecraft/mc-mods/peripheralium) - 0.4.22 -> 0.4.23
-- [PolyLib](https://www.curseforge.com/minecraft/mc-mods/polylib) - 1900.0.2-build.73 -> 1900.0.3-build.100
-- [Polymorph](https://www.curseforge.com/minecraft/mc-mods/polymorph) - 0.46.4 -> 0.46.5
-- [Rhino](https://www.curseforge.com/minecraft/mc-mods/rhino) - 1902.2.2-build.272 -> 1902.2.3-build.284
-- [Roughly Enough Items](https://www.curseforge.com/minecraft/mc-mods/roughly-enough-items) - 9.1.657 -> 9.1.682
-- [Satin API](https://www.curseforge.com/minecraft/mc-mods/satin-api) - 1.9.0 -> 1.9.1
-- [Server Performance - Smooth Chunk Save](https://www.curseforge.com/minecraft/mc-mods/smooth-chunk-save) - 3.2. -> 3.5
-- [ShetiPhianCore](https://www.curseforge.com/minecraft/mc-mods/shetiphiancore-fabric) - 1.3.11 -> 1.3.12
-- [Simple Discord Rich Presence](https://www.curseforge.com/minecraft/mc-mods/simple-discord-rich-presence) - 3.0.4-build.27 -> 3.0.6-build.39
-- [Simple Voice Chat](https://www.curseforge.com/minecraft/mc-mods/simple-voice-chat) - 2.4.3 -> 2.4.4
-- [Skin Layers 3D](https://www.curseforge.com/minecraft/mc-mods/skin-layers-3d) - 1.5.2 -> 1.6.2
-- [Structory](https://www.curseforge.com/minecraft/mc-mods/structory) - 1.3 -> 1.3.1a
-- [Structory: Towers](https://www.curseforge.com/minecraft/mc-mods/structory-towers) - 1.0.1 -> 1.0.2
-- [Spell Engine](https://www.curseforge.com/minecraft/mc-mods/spell-engine) - 0.9.25 -> 0.9.26
-- [Spellblades and Such](https://www.curseforge.com/minecraft/mc-mods/spellblade-next) - 1.0.27.5 -> 1.0.27.6
-- [Spice of Fabric](https://www.curseforge.com/minecraft/mc-mods/spice-of-fabric) - 1.6.1 -> 1.6.2
-- [SuperMartijn642's Config Lib](https://www.curseforge.com/minecraft/mc-mods/supermartijn642s-config-lib) - 1.1.8 -> 1.1.8a
-- [SuperMartijn642's Core Lib](https://www.curseforge.com/minecraft/mc-mods/supermartijn642s-core-lib) - 1.1.12b -> 1.1.17
-- [Supplementaries](https://www.curseforge.com/minecraft/mc-mods/supplementaries) - 2.3.24 -> 2.4.20
-- [Superflat World No Slimes](https://www.curseforge.com/minecraft/mc-mods/superflat-world-no-slimes) - 3.0 -> 3.2
-- [Tech-enhanced](https://www.curseforge.com/minecraft/mc-mods/tech-enhanced) - 1.0.6 -> 1.0.7
-- [Tool Stats](https://www.curseforge.com/minecraft/mc-mods/tool-stats) - 12.1.4 -> 12.1.6
-- [Trade Cycling](https://www.curseforge.com/minecraft/mc-mods/trade-cycling) - 1.0.5 -> 1.0.10
-- [UnlimitedPeripheralWorks](https://www.curseforge.com/minecraft/mc-mods/unlimitedperipheralworks) - 0.2.10 -> 0.2.12
-- [Wavey Capes](https://www.curseforge.com/minecraft/mc-mods/waveycapes) - 1.3.2 -> 1.4.4
-- [Waystones](https://www.curseforge.com/minecraft/mc-mods/waystones) - 11.4.1 -> 11.4.2
-- [WTHIT](https://www.curseforge.com/minecraft/mc-mods/wthit) - 5.19.0 -> 5.23.0
-- [YUNG's API](https://www.curseforge.com/minecraft/mc-mods/yungs-api-fabric) - 3.8.9 -> 3.8.10
-- [YUNG's Better Mineshafts](https://www.curseforge.com/minecraft/mc-mods/yungs-better-mineshafts-fabric) - 3.2.0 -> 3.2.1
-
-# Mods removed
-- [Memoryleakfix](https://www.curseforge.com/minecraft/mc-mods/memoryleakfix) - No longer updated on CF and licensing restricts repacking
+- [Chat Heads](https://www.curseforge.com/minecraft/mc-mods/chat-heads) - 0.10.31 -> 0.10.32
+- [Collective](https://www.curseforge.com/minecraft/mc-mods/collective) - 7.39 -> 7.40
+- [Create](https://www.curseforge.com/minecraft/mc-mods/create-fabric) - 0.5.1-f-build.1334 -> 0.5.1-f-build.1416
+- [Create: Steam 'n' Rails](https://www.curseforge.com/minecraft/mc-mods/create-steam-n-rails) - 1.5.3 -> 1.6.0
+- [Inventory Profiles Next](https://www.curseforge.com/minecraft/mc-mods/inventory-profiles-next) - 1.10.9 -> 1.10.10
+- [JourneyMap](https://www.curseforge.com/minecraft/mc-mods/journeymap) - 5.9.7p1 -> 5.9.8
+- [LibIPN](https://www.curseforge.com/minecraft/mc-mods/libipn) - 4.0.1 -> 4.0.2
+- [ModernFix](https://www.curseforge.com/minecraft/mc-mods/modernfix) - 5.14.0 -> 5.15.0
+- [Polymorph](https://www.curseforge.com/minecraft/mc-mods/polymorph) - 0.46.5 -> 0.46.6
+- [Simple Voice Chat](https://www.curseforge.com/minecraft/mc-mods/simple-voice-chat) - 2.5.8 -> 2.5.12
+- [Supplementaries](https://www.curseforge.com/minecraft/mc-mods/supplementaries) - 2.4.20 -> 2.4.21
+- [Tom's Simple Storage](https://www.curseforge.com/minecraft/mc-mods/toms-storage-fabric) - 1.5.9 -> 0.5.10
+- [WTHIT](https://www.curseforge.com/minecraft/mc-mods/wthit) - 5.23.0 -> 5.24.0
 
 ## Other changes:
-- Fabric Loader version 0.14.22 -> 0.15.7
-- Updated the cape list for new completionist capes
-- Buffed Impure Nether Star production
-- [Added assembler recipes for AE2 components](https://github.com/TheStaticVoid/StaTech-Industry/issues/469)
-- [Added assembler recipes for TechReborn components](https://github.com/TheStaticVoid/StaTech-Industry/issues/465)
-- [Fixed broken Pineapple Delight recipes](https://github.com/TheStaticVoid/StaTech-Industry/issues/470)
+- Completionist cape list updates

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,3 +18,4 @@ Another maintenance patch. Notably this brings the new Create update that fixes 
 
 ## Other changes:
 - Completionist cape list updates
+- [Fix missing netherite wand recipe](https://github.com/TheStaticVoid/StaTech-Industry/issues/478)

--- a/config/ftbquests/quests/chapters/2__the_steam_age.snbt
+++ b/config/ftbquests/quests/chapters/2__the_steam_age.snbt
@@ -4774,7 +4774,7 @@
 		}
 		{
 			dependencies: ["5CAAB61AA7E9FC66"]
-			description: ["The &aRedstone Control Module&r is an upgrade for your machines that allows you to control when they run using &credstone&r. By defualt, the module is operate with &6High Power&r. This means that the machine &bwill not run&r unless it's given a &cRedstone signal&r. You can invert this by &3shift+right clicking&r the &aRedstone Control Module&r in your hand. Doing so puts it in &6Low Power&r mode, which means the machine &bwill only run&r when not powered by a &cRedstone signal&r."]
+			description: ["The &aRedstone Control Module&r is an upgrade for your machines that allows you to control when they run using &credstone&r. By defualt, the module is operating with &6High Power&r. This means that the machine &bwill not run&r unless it's given a &cRedstone signal&r. You can invert this by &3shift+right clicking&r the &aRedstone Control Module&r in your hand. Doing so puts it in &6Low Power&r mode, which means the machine &bwill only run&r when not powered by a &cRedstone signal&r."]
 			id: "56FD9635F66C1D4A"
 			rewards: [
 				{

--- a/config/ftbquests/quests/chapters/2__the_steam_age.snbt
+++ b/config/ftbquests/quests/chapters/2__the_steam_age.snbt
@@ -4772,6 +4772,37 @@
 			x: 19.75d
 			y: 16.0d
 		}
+		{
+			dependencies: ["5CAAB61AA7E9FC66"]
+			description: ["The &aRedstone Control Module&r is an upgrade for your machines that allows you to control when they run using &credstone&r. By defualt, the module is operate with &6High Power&r. This means that the machine &bwill not run&r unless it's given a &cRedstone signal&r. You can invert this by &3shift+right clicking&r the &aRedstone Control Module&r in your hand. Doing so puts it in &6Low Power&r mode, which means the machine &bwill only run&r when not powered by a &cRedstone signal&r."]
+			id: "56FD9635F66C1D4A"
+			rewards: [
+				{
+					exclude_from_claim_all: true
+					id: "12DE9F4249426CDA"
+					table_id: 4870953612802399820L
+					type: "loot"
+				}
+				{
+					id: "0285300D4532E92E"
+					item: "kubejs:coin_rare"
+					type: "item"
+				}
+				{
+					id: "158F12403AA59B41"
+					type: "xp"
+					xp: 10
+				}
+			]
+			subtitle: "Fine tuned control"
+			tasks: [{
+				id: "5983C02F6002AF47"
+				item: "modern_industrialization:redstone_control_module"
+				type: "item"
+			}]
+			x: 14.0d
+			y: 7.0d
+		}
 	]
 	subtitle: ["The Basis of Industry"]
 	title: "&22 - Steam Age"

--- a/config/ftbquests/quests/reward_tables/chapter_2_late_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/chapter_2_late_rewards.snbt
@@ -286,6 +286,7 @@
 		{ item: "ironchests:netherite_barrel" }
 		{ item: "ironchests:crystal_barrel" }
 		{ item: "ironchests:diamond_barrel" }
+		{ item: "modern_industrialization:redstone_control_module" }
 	]
 	title: "Chapter 2 Rare Rewards"
 	use_title: true

--- a/config/ftbquests/quests/reward_tables/chapter_3_common_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/chapter_3_common_rewards.snbt
@@ -146,6 +146,7 @@
 		{ item: "ironchests:iron_barrel" }
 		{ item: "ironchests:crystal_barrel" }
 		{ item: "ironchests:obsidian_barrel" }
+		{ count: 8, item: "modern_industrialization:redstone_control_module" }
 	]
 	title: "Chapter 3 Common Rewards"
 	use_title: true

--- a/index.toml
+++ b/index.toml
@@ -226,7 +226,7 @@ hash = "851226d5d7632c8f85cde7dd8ad70985bffb3307f6757f1ffb9163d309d5df38"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/2__the_steam_age.snbt"
-hash = "6c383ae6af7c83359bcab9ed4a718434b7774547b56e7e473383820ad0166c6c"
+hash = "f7953526b44d320ade163e51fddb7756c6155035d58346dd3f1482c91d2d3f75"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/3__electrical_age.snbt"
@@ -278,7 +278,7 @@ hash = "0e644c7b2ff625d73e90e78f254c49307fb36a13b85cf856bce33b3245b58177"
 
 [[files]]
 file = "config/ftbquests/quests/reward_tables/chapter_2_late_rewards.snbt"
-hash = "1477830847d8186a2ff8e6603b2051d60c70583b0210579248a049ca4080ba4d"
+hash = "12700942a0551031f11823c79ac5c4bc9b18246150aeacaa9cf9819b334accb8"
 
 [[files]]
 file = "config/ftbquests/quests/reward_tables/chapter_2_rewards.snbt"
@@ -286,7 +286,7 @@ hash = "3d4a46af575bbc371d45bdcb5808427409db39d4ca43d66715215b5b8b206127"
 
 [[files]]
 file = "config/ftbquests/quests/reward_tables/chapter_3_common_rewards.snbt"
-hash = "5142d5800ca8b5c51ebfbca8524d04e6cd2a70179a370078286b221985c646a8"
+hash = "f142da48480e50b0ca6c02c7bf8dbbfe22d59c2b0652219c44a088d4d1490e2f"
 
 [[files]]
 file = "config/ftbquests/quests/reward_tables/chapter_3_legendary_rewards.snbt"
@@ -3530,7 +3530,7 @@ hash = "c5e8b5959c910700c4eb9a607635d72d1243a515ccb52ff1eed5f7b4796bb460"
 
 [[files]]
 file = "kubejs/server_scripts/mods/wands.js"
-hash = "c4bdd8e882661c9be14932f74c3466b7a7fde330da5fdca0fea2748a19d39f98"
+hash = "a5cc86bbd50f51745fcc0f2c569fe3d0610da3c5c6761d89476ad2710f1b3fb8"
 
 [[files]]
 file = "kubejs/server_scripts/mods/waystones.js"

--- a/index.toml
+++ b/index.toml
@@ -2570,7 +2570,7 @@ hash = "01e63558e1c02cd7f3fcf0ea09672cbcd93c99ed2502c5b137f568c2b46baf1c"
 
 [[files]]
 file = "kubejs/client_scripts/capes.js"
-hash = "16773f2710010cf0da8797b832f810b40e6532e77d868701e8c49d549d9a963a"
+hash = "19b57a5f84d22adc32d0f9437358a72a2df642d3599d00a379527671a9af5311"
 
 [[files]]
 file = "kubejs/client_scripts/ore_information.js"
@@ -4819,7 +4819,7 @@ metafile = true
 
 [[files]]
 file = "mods/sodium.pw.toml"
-hash = "d816ebefd14031acd676b2e7dc2d77ea7e1370903ddac480865fb68540216032"
+hash = "6050ec27f5747749fc3a85a449f82e23ed1247a3498e4cd1457b98af1ac0cbaa"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -3919,7 +3919,7 @@ metafile = true
 
 [[files]]
 file = "mods/chat-heads.pw.toml"
-hash = "2b1e7bb8f520548f7aeb4c3c0e04c520dcb37ea26a648435472b3017231e73e4"
+hash = "0108fda38a3cc0f779525ee914ddc57ca7cb6c100c7ff3ad8b4826d9ef612c1f"
 metafile = true
 
 [[files]]
@@ -3984,7 +3984,7 @@ metafile = true
 
 [[files]]
 file = "mods/collective.pw.toml"
-hash = "8aaec30736b304c4edbcc7f2b59f4b1b134ef0bddd2bd8676266cacc61264da5"
+hash = "7c8049a155c3d81a32fcae4ffd085316a0839aa620e5ba5d390db4b32cf0254b"
 metafile = true
 
 [[files]]
@@ -4029,12 +4029,12 @@ metafile = true
 
 [[files]]
 file = "mods/create-fabric.pw.toml"
-hash = "1012222a5776251e1237d414a5fecbcdaf7515bf0bfabde12875f162250c3b45"
+hash = "5606edffcf895602516007fd8a8787487c144953a2fd44cb1a073bf91fcc5bbd"
 metafile = true
 
 [[files]]
 file = "mods/create-steam-n-rails.pw.toml"
-hash = "2c7123bca04a5b25f5a6438c01cd8b3b90d9bb25475538520056602bae80ca77"
+hash = "390d37a0bbcc2de064ddc251d527ac4a642cff6f6bcca201cd04f918a325119c"
 metafile = true
 
 [[files]]
@@ -4354,7 +4354,7 @@ metafile = true
 
 [[files]]
 file = "mods/inventory-profiles-next.pw.toml"
-hash = "bb5bd678e6e929bef254ed507c9ec5b58e2a0546aaa053328511babca2211b4f"
+hash = "7bc8dc622e3ede5d7a944da8fd99e3007a831ebca37de7a800439f03783a261d"
 metafile = true
 
 [[files]]
@@ -4394,7 +4394,7 @@ metafile = true
 
 [[files]]
 file = "mods/journeymap.pw.toml"
-hash = "99a80c76403b03fff74bd4304dbb344e947c6fd8aecca762bb851362df55bcbc"
+hash = "04c2e8e80743776485390474be97ace3062a852e7be758bae94e728a16ede5dc"
 metafile = true
 
 [[files]]
@@ -4449,7 +4449,7 @@ metafile = true
 
 [[files]]
 file = "mods/libipn.pw.toml"
-hash = "54619b0bcc433985ed07ac9f6d1d2666e8f61f229ae44ea7cd0451639fcc050f"
+hash = "579cf14c5d353413d3141094cc98b97aef147abb9b04be77f7e7cee70d1033b3"
 metafile = true
 
 [[files]]
@@ -4529,7 +4529,7 @@ metafile = true
 
 [[files]]
 file = "mods/modernfix.pw.toml"
-hash = "c34bf1dc549c6efecccdd6a5e4a23292e4ae6131d6c682b76eb444726dff66e7"
+hash = "e2ab932b048532a89eeef54b0cce143bad230d782550cd98972ca75d23a66e05"
 metafile = true
 
 [[files]]
@@ -4629,7 +4629,7 @@ metafile = true
 
 [[files]]
 file = "mods/polymorph-fabric.pw.toml"
-hash = "d149c541e4fff867ea23f8793ba253e6a5c399696bb1c07252a1bc10025dc2de"
+hash = "31e2c8efef1bb128bdfee912da0aa3f76c466d030f4a4a7c97ec2a25c13bdd4d"
 metafile = true
 
 [[files]]
@@ -4774,7 +4774,7 @@ metafile = true
 
 [[files]]
 file = "mods/simple-voice-chat.pw.toml"
-hash = "d6998356ef397b8f1cd59dfe24e6efcd2a5ea25727f336d402f9a03c912cb12c"
+hash = "c59e2681fa034277c3fc36b9223a1290149c5052f2f2a40b4feca0dd8e1a5880"
 metafile = true
 
 [[files]]
@@ -4894,7 +4894,7 @@ metafile = true
 
 [[files]]
 file = "mods/supplementaries.pw.toml"
-hash = "7760927ba726b3efca220541c6efadb2ebfe77504e176b70f50a787474765ce0"
+hash = "b73c97e0e00e924ef3e11ba7e0f5ad5a873f5222567cd8dfcaa631b85e5d4a7c"
 metafile = true
 
 [[files]]
@@ -4934,7 +4934,7 @@ metafile = true
 
 [[files]]
 file = "mods/toms-storage-fabric.pw.toml"
-hash = "d9c0c3914ee619433c0f39e9b5c6ac6e7514bbc3a36de6886f56d44e6939f8d1"
+hash = "0badd4a3f92a26e35893ab78234db6e34386daa7590ca1eb0b06dd9f57be9256"
 metafile = true
 
 [[files]]
@@ -5034,7 +5034,7 @@ metafile = true
 
 [[files]]
 file = "mods/wthit.pw.toml"
-hash = "c2cfe4b80745a86609375ece3daec5c990d1710c124442ca9d7e98faaaf24c80"
+hash = "74f6eadb634945f82a5b4d00db17e588a9ae9382f0e0111150177adb72205334"
 metafile = true
 
 [[files]]

--- a/kubejs/client_scripts/capes.js
+++ b/kubejs/client_scripts/capes.js
@@ -76,4 +76,8 @@ CapeJS.addCapes(e => {
     e.register("b5e220e6-175c-46bb-b9ae-33e4dfa5d3f4", "pack_completionist");           // Mokilicious (moki)
     e.register("2bd6d8e1-bb7d-4ef6-8ca8-78b0a0c582b3", "pack_completionist");           // ZootronPrime (ZootronJustin)
     e.register("192977a2-f397-458c-84d4-dcec835f7c50", "pack_completionist");		    // Geckuss (Heinous)
+    e.register("b576f774-9e3b-4d9c-977b-be899d902e27", "pack_completionist");           // Gear (greebo)
+    e.register("62a6f98e-fbe8-4d1d-8645-53ccdf6d910f", "pack_completionist");           // Hicaro
+    e.register("19bc6152-8bae-4fa3-8333-b5b42fdf17b1", "pack_completionist");           // WaffleBagel (WeeabooWill)
+    e.register("15a0ae95-4591-4262-b5c8-dda76d982a46", "pack_completionist");           // itsClaus
 });

--- a/kubejs/server_scripts/mods/wands.js
+++ b/kubejs/server_scripts/mods/wands.js
@@ -6,6 +6,7 @@
 ServerEvents.recipes(e => {
     // -- MOD NAMESPACE UTILITY FUNCTIONS -- // 
     let st = (id) => `statech:wands/${id}`;
+    let mc = (id) => `minecraft:${id}`;
     let wa = (id) => `wands:${id}`;
 
     // Remove the default Iron Wand recipe
@@ -22,6 +23,14 @@ ServerEvents.recipes(e => {
         S: '#c:wood_sticks'
     })
     .id(st('iron_wand'));
+
+    // -- NETHERITE WAND -- //
+    e.smithing(
+        wa('netherite_wand'),
+        wa('diamond_wand'),
+        mc('netherite_ingot')
+    )
+    .id(st('netherite_wand'));
 });
 
 ServerEvents.tags('item', e => {

--- a/mods/chat-heads.pw.toml
+++ b/mods/chat-heads.pw.toml
@@ -1,13 +1,13 @@
 name = "Chat Heads"
-filename = "chat_heads-0.10.31-fabric-1.19.2.jar"
+filename = "chat_heads-0.10.32-fabric-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "b0dcb3f670509b74b21a0eda749cb1f6ce81a2e9"
+hash = "b3bc5ea9e7c5ea830754bbc2c6cd6fec092c0656"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5064428
+file-id = 5186924
 project-id = 407206

--- a/mods/collective.pw.toml
+++ b/mods/collective.pw.toml
@@ -1,13 +1,13 @@
 name = "Collective"
-filename = "collective-1.19.2-7.39.jar"
+filename = "collective-1.19.2-7.40.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "4f0f83016dc50eaa5f7488813b2b812554cfe605"
+hash = "d6680b3fb1388aebbe779264e99dd15452f88e53"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5171579
+file-id = 5177350
 project-id = 342584

--- a/mods/create-fabric.pw.toml
+++ b/mods/create-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Create Fabric"
-filename = "create-fabric-0.5.1-f-build.1334+mc1.19.2.jar"
+filename = "create-fabric-0.5.1-f-build.1416+mc1.19.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "4bdfd7d82e8e0fa37ed4a3a449cb615daa3d565a"
+hash = "92a449a218fd2cffe6e339104c635583309b06be"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5168512
+file-id = 5245232
 project-id = 624165

--- a/mods/create-steam-n-rails.pw.toml
+++ b/mods/create-steam-n-rails.pw.toml
@@ -1,13 +1,13 @@
 name = "Create: Steam 'n' Rails"
-filename = "Steam_Rails-1.5.3+fabric-mc1.19.2.jar"
+filename = "Steam_Rails-1.6.0+fabric-mc1.19.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "706a049a5d85060d10d821a9911d568e281f702b"
+hash = "f0f0ef754e174f8598e4e0aa71e99e48c3ccec6a"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5169738
+file-id = 5246809
 project-id = 688231

--- a/mods/inventory-profiles-next.pw.toml
+++ b/mods/inventory-profiles-next.pw.toml
@@ -1,13 +1,13 @@
 name = "Inventory Profiles Next"
-filename = "InventoryProfilesNext-fabric-1.19-1.10.9.jar"
+filename = "InventoryProfilesNext-fabric-1.19-1.10.10.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "ae93af87591b5ce98c927b3ef93e82b88b444285"
+hash = "fe174a9aca39547b49fba8e2c38323707a1ed7d0"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4813450
+file-id = 5209056
 project-id = 495267

--- a/mods/journeymap.pw.toml
+++ b/mods/journeymap.pw.toml
@@ -1,13 +1,13 @@
 name = "JourneyMap"
-filename = "journeymap-1.19.2-5.9.7p1-fabric.jar"
+filename = "journeymap-1.19.2-5.9.8-fabric.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "9977a93855f4c4353545ec707beb0bdc3d4f1838"
+hash = "2d0ceefd6526ba85935c7eec2cacaa668fa4fff5"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5160956
+file-id = 5208377
 project-id = 32274

--- a/mods/libipn.pw.toml
+++ b/mods/libipn.pw.toml
@@ -1,13 +1,13 @@
 name = "libIPN"
-filename = "libIPN-fabric-1.19-4.0.1.jar"
+filename = "libIPN-fabric-1.19-4.0.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "8943233549f9e41af21548e590b9c3688e19a138"
+hash = "59c4c4b649d8cfa15b32acabc131cdcf3c5ccbf1"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4870125
+file-id = 5208505
 project-id = 679177

--- a/mods/modernfix.pw.toml
+++ b/mods/modernfix.pw.toml
@@ -1,13 +1,13 @@
 name = "ModernFix"
-filename = "modernfix-fabric-5.14.0+mc1.19.2.jar"
+filename = "modernfix-fabric-5.15.0+mc1.19.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "8d7522c7b2a04b291b5b63d54f2f85eac90890c8"
+hash = "fc58adabc168987070d0e1b71927bb060d646699"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5157659
+file-id = 5203329
 project-id = 790626

--- a/mods/polymorph-fabric.pw.toml
+++ b/mods/polymorph-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Polymorph (Fabric 1.16.1 - 1.19.2)"
-filename = "polymorph-fabric-0.46.5+1.19.2.jar"
+filename = "polymorph-fabric-0.46.6+1.19.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "51c64d49ad3fd92c75f7b961e92dbd3b950bc6e5"
+hash = "8517e8ef9e272edfd9552d6d2c04e9faf4ae6831"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4813949
+file-id = 5222153
 project-id = 397434

--- a/mods/simple-voice-chat.pw.toml
+++ b/mods/simple-voice-chat.pw.toml
@@ -1,13 +1,13 @@
 name = "Simple Voice Chat"
-filename = "voicechat-fabric-1.19.2-2.5.8.jar"
+filename = "voicechat-fabric-1.19.2-2.5.12.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "1ec8bbe24e80c596114eedbed00b911579c30e48"
+hash = "0ed4c114807b24bb282f8a90f87e5df0fdac1dbe"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5164134
+file-id = 5245576
 project-id = 416089

--- a/mods/supplementaries.pw.toml
+++ b/mods/supplementaries.pw.toml
@@ -1,13 +1,13 @@
 name = "Supplementaries"
-filename = "supplementaries-1.19.2-2.4.20-fabric.jar"
+filename = "supplementaries-1.19.2-2.4.21-fabric.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "33ef4b55d374b78023235014cc065e232218d929"
+hash = "fae604ee5b0add35616a999506ed638c5b229053"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5152601
+file-id = 5226669
 project-id = 412082

--- a/mods/toms-storage-fabric.pw.toml
+++ b/mods/toms-storage-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Tom's Simple Storage Mod (Fabric)"
-filename = "toms_storage_fabric-1.19-1.5.9.jar"
+filename = "toms_storage_fabric-1.19-1.5.10.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "4cfbbf31a871bc03958c8bbc9b892f9110757ab4"
+hash = "b74054499a4c0b4cb3ce91a49f7819132afcea97"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4649851
+file-id = 5211215
 project-id = 396826

--- a/mods/wthit.pw.toml
+++ b/mods/wthit.pw.toml
@@ -1,13 +1,13 @@
 name = "WTHIT"
-filename = "wthit-fabric-5.23.0.jar"
+filename = "wthit-fabric-5.24.0.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "fda6f261a8ab244e9410a5fcfad17a948d4f88aa"
+hash = "5253f3b526f44b3cb75dcdd75b16457f34f4a404"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5173654
+file-id = 5208193
 project-id = 440979

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "1ec537323012ed32d113a1f311d4aebb2c4ee1e71096e7be211f7b21b06e51f5"
+hash = "b676b05abdebbad79970dc1231c389acdd69f8c16dabb21fdef4752b44eda128"
 
 [versions]
 fabric = "0.15.7"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "cd84e42a7b6211408c7bdf2e77363d28fc7220f87f03940a3110e587c2f43499"
+hash = "5231cd2d9186e676dd4a0baa613c4d2f29a0cc621a429e935db07bbdc7271230"
 
 [versions]
 fabric = "0.15.7"

--- a/pack.toml
+++ b/pack.toml
@@ -1,6 +1,6 @@
 name = "StaTech Industry"
 author = "static"
-version = "1.1.12"
+version = "1.1.13"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "b676b05abdebbad79970dc1231c389acdd69f8c16dabb21fdef4752b44eda128"
+hash = "cd84e42a7b6211408c7bdf2e77363d28fc7220f87f03940a3110e587c2f43499"
 
 [versions]
 fabric = "0.15.7"


### PR DESCRIPTION
# StaTech Industry 1.1.13 Changelog:
Another maintenance patch. Notably this brings the new Create update that fixes the crash-to-desktop when viewing certain Create recipes.

## Mods updated:
- [Chat Heads](https://www.curseforge.com/minecraft/mc-mods/chat-heads) - 0.10.31 -> 0.10.32
- [Collective](https://www.curseforge.com/minecraft/mc-mods/collective) - 7.39 -> 7.40
- [Create](https://www.curseforge.com/minecraft/mc-mods/create-fabric) - 0.5.1-f-build.1334 -> 0.5.1-f-build.1416
- [Create: Steam 'n' Rails](https://www.curseforge.com/minecraft/mc-mods/create-steam-n-rails) - 1.5.3 -> 1.6.0
- [Inventory Profiles Next](https://www.curseforge.com/minecraft/mc-mods/inventory-profiles-next) - 1.10.9 -> 1.10.10
- [JourneyMap](https://www.curseforge.com/minecraft/mc-mods/journeymap) - 5.9.7p1 -> 5.9.8
- [LibIPN](https://www.curseforge.com/minecraft/mc-mods/libipn) - 4.0.1 -> 4.0.2
- [ModernFix](https://www.curseforge.com/minecraft/mc-mods/modernfix) - 5.14.0 -> 5.15.0
- [Polymorph](https://www.curseforge.com/minecraft/mc-mods/polymorph) - 0.46.5 -> 0.46.6
- [Simple Voice Chat](https://www.curseforge.com/minecraft/mc-mods/simple-voice-chat) - 2.5.8 -> 2.5.12
- [Supplementaries](https://www.curseforge.com/minecraft/mc-mods/supplementaries) - 2.4.20 -> 2.4.21
- [Tom's Simple Storage](https://www.curseforge.com/minecraft/mc-mods/toms-storage-fabric) - 1.5.9 -> 0.5.10
- [WTHIT](https://www.curseforge.com/minecraft/mc-mods/wthit) - 5.23.0 -> 5.24.0

## Other changes:
- Completionist cape list updates
- [Fix missing netherite wand recipe](https://github.com/TheStaticVoid/StaTech-Industry/issues/478)
- [Added quest for the Redstone Control Module](https://github.com/TheStaticVoid/StaTech-Industry/commit/6a82a48b3a1adc86e51b4776e5818ccdea5c2663)