### PR TITLE
Remove double space in bronze mixer description

### DIFF
--- a/config/ftbquests/quests/chapters/2__the_steam_age.snbt
+++ b/config/ftbquests/quests/chapters/2__the_steam_age.snbt
@@ -584,7 +584,7 @@
 		}
 		{
 			dependencies: ["343C68866C58ADC3"]
-			description: ["The &6Bronze Mixer&r will help you &amix dusts&r, giving you a better ratio for &6Bronze&r and &aFire Clay&r, as well as opening up a recipe for  &eUncooked Steel&r. It can also create &dCobblestone&r and &3Clay&r."]
+			description: ["The &6Bronze Mixer&r will help you &amix dusts&r, giving you a better ratio for &6Bronze&r and &aFire Clay&r, as well as opening up a recipe for &eUncooked Steel&r. It can also create &dCobblestone&r and &3Clay&r."]
 			id: "693368CF3E13AB7A"
 			rewards: [
 				{


### PR DESCRIPTION
Spotted whilst playing.