### PR TITLE
Fix KubeJS script exceptions, cutting machine recipe helper, and food item returns

### DIFF
--- a/kubejs/server_scripts/machine_recipe_helper.js
+++ b/kubejs/server_scripts/machine_recipe_helper.js
@@ -453,7 +453,7 @@ let cryogenicPrecipitator = (
  * @param {MIItem[]|MIItem} item_outputs - Array of item outputs
  */
 let cuttingMachine = (event, id, eu, duration, item_inputs, item_outputs) => {
-    let lubricant = { amount: 10, fluid: mi('lubricant') };
+    let lubricant = [{ amount: 10, fluid: mi('lubricant') }];
     event
         .custom(
             newMachineRecipe(

--- a/kubejs/server_scripts/mods/modern_industrialization/cutting_machine.js
+++ b/kubejs/server_scripts/mods/modern_industrialization/cutting_machine.js
@@ -15,20 +15,11 @@ ServerEvents.recipes((event) => {
         recipesToRemove.push(recipe.getId());
         let recipeJson = recipe.json;
         let inputs = recipeJson.get('fluid_inputs');
-        let amount;
 
-        if (inputs.get(0) != null) {
-            amount = inputs.get(0).get('amount');
-            if (amount == 1) {
-                recipeJson
-                    .get('fluid_inputs')
-                    .get(0)
-                    .add('amount', lubricantAmount);
-            }
-        } else {
-            amount = inputs.get('amount');
-            if (amount == 1) {
-                recipeJson.get('fluid_inputs').add('amount', lubricantAmount);
+        if (inputs != null && inputs.isJsonArray() && inputs.getAsJsonArray().size() > 0) {
+            let firstInput = inputs.getAsJsonArray().get(0).getAsJsonObject();
+            if (firstInput.has('amount') && firstInput.get('amount').getAsInt() == 1) {
+                firstInput.addProperty('amount', lubricantAmount);
             }
         }
         event.custom(recipeJson).id(st(recipe.getPath()));

--- a/kubejs/server_scripts/statech_food.js
+++ b/kubejs/server_scripts/statech_food.js
@@ -19,7 +19,7 @@ ItemEvents.foodEaten((event) => {
      
 
     EatenOutputs.forEach((eatenOutput) => {
-        if (event.getItem() == Item.of(eatenOutput[0])) {
+        if (event.getItem().id == eatenOutput[0]) {
             event.getPlayer().addItem(Item.of(eatenOutput[1]));
         }
     });

--- a/kubejs/server_scripts/trial_chambers_nerf.js
+++ b/kubejs/server_scripts/trial_chambers_nerf.js
@@ -2,25 +2,25 @@ MoreJS.structureLoad((event) => {
     if (event.id.includes('trial_chambers')) {
         event.forEachPalettes((palette) => {
             palette.forEach((blockInfo) => {
-                if (blockInfo.id == 'minecraft:jigsaw') {
+                if (blockInfo.id == 'minecraft:jigsaw' && blockInfo.getNbt() != null) {
                     if (
-                        blockInfo.getNbt().get('final_state') ==
+                        blockInfo.getNbt().getString('final_state') ==
                         'minecraft:waxed_oxidized_copper'
                     )
                         blockInfo
-                            .nbt()
+                            .getNbt()
                             .putString(
                                 'final_state',
                                 'kubejs:decorative_waxed_oxidized_copper'
                             );
                 }
-                if (blockInfo.id == 'minecraft:jigsaw') {
+                if (blockInfo.id == 'minecraft:jigsaw' && blockInfo.getNbt() != null) {
                     if (
-                        blockInfo.getNbt().get('final_state') ==
+                        blockInfo.getNbt().getString('final_state') ==
                         'minecraft:waxed_copper_block'
                     )
                         blockInfo
-                            .nbt()
+                            .getNbt()
                             .putString(
                                 'final_state',
                                 'kubejs:decorative_waxed_copper_block'


### PR DESCRIPTION
Fixed several runtime exceptions and broken logic paths:
1. Fixed `cutting_machine.js` Gson property mutation and bounds checking when modifying cutting machine recipes.
2. Updated `cuttingMachine` helper to emit `fluid_inputs` as an array rather than an object to comply with Modern Industrialization's recipe schema.
3. Fixed `statech_food.js` item comparison logic to check item IDs instead of Java object instance identity.
4. Corrected MoreJS NBT access calls in `trial_chambers_nerf.js` to prevent `TypeError` exceptions on structure load.