### PR TITLE
don't format multiblock definitions

### DIFF
--- a/kubejs/.prettierignore
+++ b/kubejs/.prettierignore
@@ -1,0 +1,2 @@
+startup_scripts/modern_industrialization/multiblocks/
+startup_scripts/mi_tweaks/multiblocks


### PR DESCRIPTION
adds `startup_scripts/modern_industrialization/multiblocks/` and `startup_scripts/mi_tweaks/multiblocks` to a `.prettierignore`, exempting them from the usual formatting rules.