### PR TITLE
Buff enderium cable to EV

### DIFF
--- a/kubejs/server_scripts/mods/modern_industrialization.js
+++ b/kubejs/server_scripts/mods/modern_industrialization.js
@@ -480,7 +480,6 @@ ServerEvents.tags('item', (event) => {
     const HV_WIRE = [
         mi('aluminum_cable'),
         mi('kanthal_cable'),
-        mi('enderium_cable'),
     ];
     HV_WIRE.forEach((id) => {
         event.add('kubejs:hv_wire', id);
@@ -489,6 +488,7 @@ ServerEvents.tags('item', (event) => {
     const EV_WIRE = [
         mi('annealed_copper_cable'),
         mi('platinum_cable'),
+        mi('enderium_cable'),
         mi('tungstensteel_cable'),
     ];
     EV_WIRE.forEach((id) => {

--- a/kubejs/startup_scripts/modern_industrialization/materials.js
+++ b/kubejs/startup_scripts/modern_industrialization/materials.js
@@ -265,7 +265,7 @@ MIMaterialEvents.addMaterials((event) => {
                 'wire'
             )
             .block('iron')
-            .cable('hv')
+            .cable('ev')
             .machineCasing(12.0)
             .pipeCasing(12.0)
             .defaultRecipes();
@@ -417,20 +417,15 @@ MIMaterialEvents.addMaterials((event) => {
         }
     );
 
-    event.createMaterial(
-        'Netherite',
-        'netherite',
-        0x4c484c,
-        (builder) => {
-            builder
-                .hardness('very_hard')
-                .materialSet('dull')
-                .addParts('hot_ingot')
-                .addExternalPart('ingot', mc('netherite_ingot'))
-                .addExternalPart('block', mc('netherite_block'))
-                .addExternalPart('dust', ei('netherite_dust'))
-        }
-    )
+    event.createMaterial('Netherite', 'netherite', 0x4c484c, (builder) => {
+        builder
+            .hardness('very_hard')
+            .materialSet('dull')
+            .addParts('hot_ingot')
+            .addExternalPart('ingot', mc('netherite_ingot'))
+            .addExternalPart('block', mc('netherite_block'))
+            .addExternalPart('dust', ei('netherite_dust'));
+    });
 });
 
 MIMaterialEvents.modifyMaterial('beryllium', (event) => {


### PR DESCRIPTION
Enderium is a material that almost every player will make only *after* they have already made annealed copper, so giving it an HV cable feels entirely out of place.