### PR TITLE
refactor greenhouse recipes and also restore their old formatting

### DIFF
--- a/kubejs/server_scripts/mods/modern_industrialization/greenhouse.js
+++ b/kubejs/server_scripts/mods/modern_industrialization/greenhouse.js
@@ -3,396 +3,152 @@
 // STATECH INDUSTRY
 // -----------------------------------------
 
+/**
+ *   @param {string} sapling Namespaced identifier of this tree's sapling
+ *   @param {string} log Namespaced identifier of this tree's log
+ *   @param {string} leaves Namespaced identifier of this tree's leaves
+ *   @param {string} fluid Namespaced identifier of the fluid needed to grow this tree
+ *   @param {extraDrop}
+ *
+ * @example
+ * ```javascript
+ *  Tree(mc('spruce_sapling'), mc('spruce_log'), mc('spruce_leaves'), mc('water'));
+ *  Tree(mc('oak_sapling'), mc('oak_log'), mc('oak_leaves'), mc('water'),
+ *      {
+ *          item: mc('apple'),
+ *          amount: 1,
+ *          probability: 0.12
+ *      }
+ *  );
+ * ```
+ */
+function Tree(sapling, log, leaves, fluid, extraDrop) {
+    return {
+        sapling: sapling,
+        log: log,
+        leaves: leaves,
+        fluid: fluid,
+        extraDrop: extraDrop,
+    };
+}
+
 ServerEvents.recipes((event) => {
     // -- MOD NAMESPACE UTILITY FUNCTIONS -- //
     let st = (id) => `statech:modern_industrialization/greenhouse/${id}`;
 
     // This is all the saplings in the game with their corresponding logs and leaves
 
+    // prettier-ignore
     const saplingLogList = [
-        // Sapling                              Log                             Leaves                                  Fluid
-        [
-            mc('spruce_sapling'),
-            mc('spruce_log'),
-            mc('spruce_leaves'),
-            mc('water'),
-        ],
-        [mc('birch_sapling'), mc('birch_log'), mc('birch_leaves'), mc('water')],
-        [
-            mc('jungle_sapling'),
-            mc('jungle_log'),
-            mc('jungle_leaves'),
-            mc('water'),
-        ],
-        [
-            mc('acacia_sapling'),
-            mc('acacia_log'),
-            mc('acacia_leaves'),
-            mc('water'),
-        ],
-        [
-            mc('mangrove_propagule'),
-            mc('mangrove_log'),
-            mc('mangrove_leaves'),
-            mc('water'),
-        ],
-        [
-            mc('cherry_sapling'),
-            mc('cherry_log'),
-            mc('cherry_leaves'),
-            mc('water'),
-        ],
-        [
-            mc('crimson_fungus'),
-            mc('crimson_stem'),
-            mc('nether_wart_block'),
-            mi('blood'),
-        ],
-        [
-            mc('warped_fungus'),
-            mc('warped_stem'),
-            mc('warped_wart_block'),
-            mi('blood'),
-        ],
-        [nm('maple_sapling'), nm('maple_log'), nm('maple_leaves'), mc('water')],
-        [
-            nm('red_maple_sapling'),
-            nm('maple_log'),
-            nm('red_maple_leaves'),
-            mc('water'),
-        ],
-        [
-            nm('willow_sapling'),
-            nm('willow_log'),
-            nm('willow_leaves'),
-            mc('water'),
-        ],
-        [
-            nm('yellow_birch_sapling'),
-            mc('birch_log'),
-            nm('yellow_birch_leaves'),
-            mc('water'),
-        ],
-        [
-            nm('pale_cherry_sapling'),
-            mc('cherry_log'),
-            nm('pale_cherry_leaves'),
-            mc('water'),
-        ],
-        [
-            ap('twisted_sapling'),
-            ap('twisted_log'),
-            ap('twisted_leaves'),
-            mc('water'),
-        ],
+              // Sapling                    Log                   Leaves                      Fluid
+        Tree(mc('spruce_sapling'),       mc('spruce_log'),     mc('spruce_leaves'),        mc('water')),
+        Tree(mc('birch_sapling'),        mc('birch_log'),      mc('birch_leaves'),         mc('water')),
+        Tree(mc('jungle_sapling'),       mc('jungle_log'),     mc('jungle_leaves'),        mc('water')),
+        Tree(mc('acacia_sapling'),       mc('acacia_log'),     mc('acacia_leaves'),        mc('water')),
+        Tree(mc('mangrove_propagule'),   mc('mangrove_log'),   mc('mangrove_leaves'),      mc('water')),
+        Tree(mc('cherry_sapling'),       mc('cherry_log'),     mc('cherry_leaves'),        mc('water')),
+        Tree(mc('crimson_fungus'),       mc('crimson_stem'),   mc('nether_wart_block'),    mi('blood')),
+        Tree(mc('warped_fungus'),        mc('warped_stem'),    mc('warped_wart_block'),    mi('blood')),
+        Tree(nm('maple_sapling'),        nm('maple_log'),      nm('maple_leaves'),         mc('water')),
+        Tree(nm('red_maple_sapling'),    nm('maple_log'),      nm('red_maple_leaves'),     mc('water')),
+        Tree(nm('willow_sapling'),       nm('willow_log'),     nm('willow_leaves'),        mc('water')),
+        Tree(nm('yellow_birch_sapling'), mc('birch_log'),      nm('yellow_birch_leaves'),  mc('water')),
+        Tree(nm('pale_cherry_sapling'),  mc('cherry_log'),     nm('pale_cherry_leaves'),   mc('water')),
+        Tree(ap('twisted_sapling'),      ap('twisted_log'),    ap('twisted_leaves'),       mc('water')),
     ];
-
+    // prettier-ignore
     const spectrumSaplingList = [
-        [
-            sp('orange_sapling'),
-            sp('orange_log'),
-            sp('orange_leaves'),
-            mc('water'),
-        ],
-        [
-            sp('magenta_sapling'),
-            sp('magenta_log'),
-            sp('magenta_leaves'),
-            mc('water'),
-        ],
-        [
-            sp('light_blue_sapling'),
-            sp('light_blue_log'),
-            sp('light_blue_leaves'),
-            mc('water'),
-        ],
-        [
-            sp('yellow_sapling'),
-            sp('yellow_log'),
-            sp('yellow_leaves'),
-            mc('water'),
-        ],
-        [sp('lime_sapling'), sp('lime_log'), sp('lime_leaves'), mc('water')],
-        [sp('pink_sapling'), sp('pink_log'), sp('pink_leaves'), mc('water')],
-        [sp('cyan_sapling'), sp('cyan_log'), sp('cyan_leaves'), mc('water')],
-        [
-            sp('purple_sapling'),
-            sp('purple_log'),
-            sp('purple_leaves'),
-            mc('water'),
-        ],
-        [sp('blue_sapling'), sp('blue_log'), sp('blue_leaves'), mc('water')],
-        [sp('brown_sapling'), sp('brown_log'), sp('brown_leaves'), mc('water')],
-        [sp('green_sapling'), sp('green_log'), sp('green_leaves'), mc('water')],
-        [sp('red_sapling'), sp('red_log'), sp('red_leaves'), mc('water')],
-        [sp('black_sapling'), sp('black_log'), sp('black_leaves'), mc('water')],
-        [sp('white_sapling'), sp('white_log'), sp('white_leaves'), mc('water')],
-        [sp('gray_sapling'), sp('gray_log'), sp('gray_leaves'), mc('water')],
-        [
-            sp('light_gray_sapling'),
-            sp('light_gray_log'),
-            sp('light_gray_leaves'),
-            mc('water'),
-        ],
+        Tree(sp('orange_sapling'),       sp('orange_log'),     sp('orange_leaves'),        mc('water')),
+        Tree(sp('magenta_sapling'),      sp('magenta_log'),    sp('magenta_leaves'),       mc('water')),
+        Tree(sp('light_blue_sapling'),   sp('light_blue_log'), sp('light_blue_leaves'),    mc('water')),
+        Tree(sp('yellow_sapling'),       sp('yellow_log'),     sp('yellow_leaves'),        mc('water')),
+        Tree(sp('lime_sapling'),         sp('lime_log'),       sp('lime_leaves'),          mc('water')),
+        Tree(sp('pink_sapling'),         sp('pink_log'),       sp('pink_leaves'),          mc('water')),
+        Tree(sp('cyan_sapling'),         sp('cyan_log'),       sp('cyan_leaves'),          mc('water')),
+        Tree(sp('purple_sapling'),       sp('purple_log'),     sp('purple_leaves'),        mc('water')),
+        Tree(sp('blue_sapling'),         sp('blue_log'),       sp('blue_leaves'),          mc('water')),
+        Tree(sp('brown_sapling'),        sp('brown_log'),      sp('brown_leaves'),         mc('water')),
+        Tree(sp('green_sapling'),        sp('green_log'),      sp('green_leaves'),         mc('water')),
+        Tree(sp('red_sapling'),          sp('red_log'),        sp('red_leaves'),           mc('water')),
+        Tree(sp('black_sapling'),        sp('black_log'),      sp('black_leaves'),         mc('water')),
+        Tree(sp('white_sapling'),        sp('white_log'),      sp('white_leaves'),         mc('water')),
+        Tree(sp('gray_sapling'),         sp('gray_log'),       sp('gray_leaves'),          mc('water')),
+        Tree(sp('light_gray_sapling'),   sp('light_gray_log'), sp('light_gray_leaves'),    mc('water')),
     ];
-
+    // prettier-ignore
     const saplingWithExtraDrops = [
-        [
-            mc('oak_sapling'),
-            mc('oak_log'),
-            mc('oak_leaves'),
-            mc('water'),
-            mc('apple'),
-            0.75,
-        ],
-        [
-            mc('dark_oak_sapling'),
-            mc('dark_oak_log'),
-            mc('dark_oak_leaves'),
-            mc('water'),
-            mc('apple'),
-            0.5,
-        ],
-        [
-            nm('autumnal_oak_sapling'),
-            mc('oak_log'),
-            nm('autumnal_oak_leaves'),
-            mc('water'),
-            nm('pear'),
-            0.75,
-        ],
-        [
-            nm('walnut_sapling'),
-            nm('walnut_log'),
-            nm('walnut_leaves'),
-            mc('water'),
-            nm('walnuts'),
-            0.05,
-        ],
-        [
-            nm('pine_sapling'),
-            nm('pine_log'),
-            nm('pine_leaves'),
-            mc('water'),
-            nm('pine_nuts'),
-            0.1,
-        ],
-        [
-            cud('avocado_sapling'),
-            cud('avocado_log'),
-            cud('avocado_leaves'),
-            mc('water'),
-            cud('avocado'),
-            0.5,
-        ],
+        Tree(mc('oak_sapling'),          mc('oak_log'),         mc('oak_leaves'),          mc('water'),     { item: mc('apple'),     probability: 0.75 }),
+        Tree(mc('dark_oak_sapling'),     mc('dark_oak_log'),    mc('dark_oak_leaves'),     mc('water'),     { item: mc('apple'),     probability: 0.5  }),
+        Tree(nm('autumnal_oak_sapling'), mc('oak_log'),         nm('autumnal_oak_leaves'), mc('water'),     { item: nm('pear'),      probability: 0.75 }),
+        Tree(nm('walnut_sapling'),       nm('walnut_log'),      nm('walnut_leaves'),       mc('water'),     { item: nm('walnuts'),   probability: 0.05 }),
+        Tree(nm('pine_sapling'),         nm('pine_log'),        nm('pine_leaves'),         mc('water'),     { item: nm('pine_nuts'), probability: 0.1  }),
+        Tree(cud('avocado_sapling'),     cud('avocado_log'),    cud('avocado_leaves'),     mc('water'),     { item: cud('avocado'),  probability: 0.5  }),
     ];
-
-    // For every sapling, add a regular and bone meal variant of the recipe
-    saplingLogList.forEach((woodType) => {
-        let sapling = woodType[0];
-        let log = woodType[1];
-        let leaves = woodType[2];
-        let fluid = woodType[3];
+    function makeGreenhouseRecipes(tree, condition) {
+        let { log, sapling, leaves, fluid } = tree;
         let id = `${log.split(':')[1]}_from_${sapling.split(':')[1]}`;
-
-        // Fixes duplicate ID issue between the two palm logs
-        // if (log.split(':')[1] == 'palm_log' && log.split(':')[0] == 'byg')
-        // id += '_byg';
-
-        greenhouse(
-            event,
-            st(id),
-            8,
-            1200,
-            [{ amount: 1, item: sapling, probability: 0.0 }],
-            [
-                { amount: 8, item: log },
-                { amount: 16, item: leaves },
-                { amount: 1, item: sapling, probability: 0.5 },
-            ],
-            [{ amount: 100, fluid: fluid }]
-        );
-
-        fluid = mi(`nutrient_rich_${fluid.split(':')[1]}`);
-        greenhouse(
-            event,
-            st(`${id}_bonemeal`),
-            8,
-            1200,
-            [{ amount: 1, item: sapling, probability: 0.0 }],
-            [
-                { amount: 16, item: log },
-                { amount: 32, item: leaves },
-                { amount: 1, item: sapling },
-            ],
-            [{ amount: 100, fluid: fluid }]
-        );
-
-        greenhouse(
-            event,
-            st(`${id}_npk`),
-            8,
-            1200,
-            [{ amount: 1, item: sapling, probability: 0.0 }],
-            [
-                { amount: 32, item: log },
-                { amount: 64, item: leaves },
-                { amount: 2, item: sapling },
-            ],
-            [{ amount: 100, fluid: ei('npk_fertilizer') }]
-        );
-    });
-    spectrumSaplingList.forEach((woodType) => {
-        let sapling = woodType[0];
-        let log = woodType[1];
-        let leaves = woodType[2];
-        let fluid = woodType[3];
-        let id = `${log.split(':')[1]}_from_${sapling.split(':')[1]}`;
-
-        // Fixes duplicate ID issue between the two palm logs
-        // if (log.split(':')[1] == 'palm_log' && log.split(':')[0] == 'byg')
-        // id += '_byg';
-
-        greenhouse(
-            event,
-            st(id),
-            8,
-            1200,
-            [{ amount: 1, item: sapling, probability: 0.0 }],
-            [
-                { amount: 8, item: log },
-                { amount: 16, item: leaves },
-                { amount: 1, item: sapling, probability: 0.5 },
-            ],
-            [{ amount: 100, fluid: fluid }],
-            'spectrum:polished_onyx',
-            'below'
-        );
-
-        fluid = mi(`nutrient_rich_${fluid.split(':')[1]}`);
-        greenhouse(
-            event,
-            st(`${id}_bonemeal`),
-            8,
-            1200,
-            [{ amount: 1, item: sapling, probability: 0.0 }],
-            [
-                { amount: 16, item: log },
-                { amount: 32, item: leaves },
-                { amount: 1, item: sapling },
-            ],
-            [{ amount: 100, fluid: fluid }],
-            'spectrum:polished_onyx',
-            'below'
-        );
-
-        greenhouse(
-            event,
-            st(`${id}_npk`),
-            8,
-            1200,
-            [{ amount: 1, item: sapling, probability: 0.0 }],
-            [
-                { amount: 32, item: log },
-                { amount: 64, item: leaves },
-                { amount: 2, item: sapling },
-            ],
-            [{ amount: 100, fluid: ei('npk_fertilizer') }],
-            'spectrum:polished_onyx',
-            'below'
-        );
-    });
-
-    saplingWithExtraDrops.forEach((woodType) => {
-        let sapling = woodType[0];
-        let log = woodType[1];
-        let leaves = woodType[2];
-        let fluid = woodType[3];
-        let extraDrop = woodType[4];
-        let extraDropChance = woodType[5];
-        let id = `${log.split(':')[1]}_from_${sapling.split(':')[1]}`;
-
-        // Fixes duplicate ID issue between the two palm logs
-        // if (log.split(':')[1] == 'palm_log' && log.split(':')[0] == 'byg')
-        // id += '_byg';
-        let extraDropChanceRoll = 1;
-        if (woodType[5] * 8 < 1) extraDropChanceRoll = woodType[5] * 8;
-        if (woodType[5] * 8 > 1 && woodType[5] < 1) {
-            extraDropChanceRoll = null;
-            extraDropChance = Math.ceil(woodType[5] * 8);
-        } else {
-            extraDropChance = woodType[5] * 8;
-        }
-        greenhouse(
-            event,
-            st(id),
-            8,
-            1200,
-            [{ amount: 1, item: sapling, probability: 0.0 }],
-            [
-                { amount: 8, item: log },
-                { amount: 16, item: leaves },
-                { amount: 1, item: sapling, probability: 0.5 },
+        // calling the "helper function" directly was SUPER verbose, so this is a more concise wrapper around it.
+        const greenhouseHelper = (fluid, multiplier, id_suffix) => {
+            let treeOutputs = [
+                { amount: multiplier * 8, item: log },
+                { amount: multiplier * 16, item: leaves },
                 {
-                    amount: extraDropChance,
-                    item: extraDrop,
-                    probability: extraDropChanceRoll,
+                    amount: Math.ceil(multiplier / 2),
+                    item: sapling,
+                    probability: 0.5,
                 },
-            ],
-            [{ amount: 100, fluid: fluid }]
-        );
+            ];
 
-        if (woodType[5] * 16 < 1) extraDropChanceRoll = woodType[5] * 16;
-        if (woodType[5] * 16 > 1 && woodType[5] * 8 < 1) {
-            extraDropChanceRoll = null;
-            extraDropChance = Math.ceil(woodType[5] * 16);
-        } else {
-            extraDropChance = woodType[5] * 16;
-        }
-        fluid = mi(`nutrient_rich_${fluid.split(':')[1]}`);
-        greenhouse(
-            event,
-            st(`${id}_bonemeal`),
-            8,
-            1200,
-            [{ amount: 1, item: sapling, probability: 0.0 }],
-            [
-                { amount: 16, item: log },
-                { amount: 32, item: leaves },
-                { amount: 1, item: sapling },
-                {
-                    amount: extraDropChance,
-                    item: extraDrop,
-                    probability: extraDropChanceRoll,
-                },
-            ],
-            [{ amount: 100, fluid: fluid }]
-        );
+            if (tree.extraDrop) {
+                let extra = {
+                    item: tree.extraDrop.item,
+                    probability: tree.extraDrop.probability,
+                    amount: multiplier,
+                };
+                treeOutputs.push(extra);
+            }
+            // handle trees with block conditions
+            if (condition.block && condition.direction) {
+                greenhouse(
+                    event,
+                    st(id + id_suffix),
+                    8,
+                    1200,
+                    [{ amount: 1, item: sapling, probability: 0.0 }],
+                    treeOutputs,
+                    [{ amount: 100, fluid: fluid }],
+                    condition.block,
+                    condition.direction
+                );
+            } else {
+                greenhouse(
+                    event,
+                    st(id + id_suffix),
+                    8,
+                    1200,
+                    [{ amount: 1, item: sapling, probability: 0.0 }],
+                    treeOutputs,
+                    [{ amount: 100, fluid: fluid }]
+                );
+            }
+        };
 
-        if (woodType[5] * 32 < 1) extraDropChanceRoll = woodType[5] * 32;
-        if (woodType[5] * 32 > 1 && woodType[5] * 16 < 1) {
-            extraDropChanceRoll = null;
-            extraDropChance = Math.ceil(woodType[5] * 32);
-        } else {
-            extraDropChance = woodType[5] * 32;
-        }
-        greenhouse(
-            event,
-            st(`${id}_npk`),
-            8,
-            1200,
-            [{ amount: 1, item: sapling, probability: 0.0 }],
-            [
-                { amount: 32, item: log },
-                { amount: 64, item: leaves },
-                { amount: 2, item: sapling },
-                {
-                    amount: extraDropChance,
-                    item: extraDrop,
-                    probability: extraDropChanceRoll,
-                },
-            ],
-            [{ amount: 100, fluid: ei('npk_fertilizer') }]
+        // For every sapling, add a regular and bone meal variant of the recipe
+        greenhouseHelper(fluid, 1, '');
+        greenhouseHelper(
+            mi(`nutrient_rich_${fluid.split(':')[1]}`),
+            2,
+            '_bonemeal'
         );
-    });
+        greenhouseHelper(ei('npk_fertilizer'), 4, '_npk');
+    }
+
+    saplingLogList.forEach((tree) => makeGreenhouseRecipes(tree, false));
+    spectrumSaplingList.forEach((tree) =>
+        makeGreenhouseRecipes(tree, {
+            block: sp('polished_onyx'),
+            direction: 'below',
+        })
+    );
+    saplingWithExtraDrops.forEach((tree) => makeGreenhouseRecipes(tree, false));
 });

--- a/kubejs/server_scripts/mods/modern_industrialization/greenhouse.js
+++ b/kubejs/server_scripts/mods/modern_industrialization/greenhouse.js
@@ -103,7 +103,7 @@ ServerEvents.recipes((event) => {
                 let extra = {
                     item: tree.extraDrop.item,
                     probability: tree.extraDrop.probability,
-                    amount: multiplier,
+                    amount: multiplier * 2,
                 };
                 treeOutputs.push(extra);
             }

--- a/kubejs/server_scripts/mods/modern_industrialization/greenhouse.js
+++ b/kubejs/server_scripts/mods/modern_industrialization/greenhouse.js
@@ -8,7 +8,7 @@
  *   @param {string} log Namespaced identifier of this tree's log
  *   @param {string} leaves Namespaced identifier of this tree's leaves
  *   @param {string} fluid Namespaced identifier of the fluid needed to grow this tree
- *   @param {extraDrop}
+ *   @param {MIItem} extraDrop MIItem object containing an item and probability for any extra drops a tree may have, like apples.
  *
  * @example
  * ```javascript


### PR DESCRIPTION
Makes the greenhouse recipe script generally way more readable.[^1] This includes restoring the original formatting of the file, and more importantly, representing the trees as objects with named properties rather than arrays. I also refactored the code that actually _uses_ the tree definitions to be a little more compact and hopefully easier to follow.

This STILL isn't quite up to my ideal standards[^2], but it is 5 in the morning and I need to stop looking at this file... I've tested that everything Works:tm: up to the point of loading without KubeJS errors and the recipes appearing correctly in EMI.

[^1]: I am waving my cross and shouting "Begone! Foul demon!" at all the `woodType[n]` accesses that were present before.
[^2]: declaring `mc('water')` for like 99% of the trees is insane when that information could be _assumed_ unless a fluid is explicitly provided